### PR TITLE
feat: add journal foundation layer

### DIFF
--- a/src/main/java/ve/edu/unimet/so/project2/journal/JournalEntry.java
+++ b/src/main/java/ve/edu/unimet/so/project2/journal/JournalEntry.java
@@ -1,0 +1,157 @@
+package ve.edu.unimet.so.project2.journal;
+
+import ve.edu.unimet.so.project2.journal.undo.CreateDirectoryUndoData;
+import ve.edu.unimet.so.project2.journal.undo.CreateFileUndoData;
+import ve.edu.unimet.so.project2.journal.undo.DeleteDirectoryUndoData;
+import ve.edu.unimet.so.project2.journal.undo.DeleteFileUndoData;
+import ve.edu.unimet.so.project2.journal.undo.JournalUndoData;
+import ve.edu.unimet.so.project2.journal.undo.UpdateRenameUndoData;
+import ve.edu.unimet.so.project2.process.IoOperationType;
+
+public final class JournalEntry {
+
+    private final String transactionId;
+    private final IoOperationType operationType;
+    private final String targetPath;
+    private JournalStatus status;
+    private final JournalUndoData undoData;
+    private final String targetNodeId;
+    private final String ownerUserId;
+    private final String description;
+
+    JournalEntry(
+            String transactionId,
+            IoOperationType operationType,
+            String targetPath,
+            JournalStatus status,
+            JournalUndoData undoData,
+            String targetNodeId,
+            String ownerUserId,
+            String description) {
+        this.transactionId = requireNonBlank(transactionId, "transactionId");
+        if (operationType == null) {
+            throw new IllegalArgumentException("operationType cannot be null");
+        }
+        if (operationType == IoOperationType.READ) {
+            throw new IllegalArgumentException("READ operations cannot be journaled");
+        }
+        this.targetPath = requireNonBlank(targetPath, "targetPath");
+        if (status == null) {
+            throw new IllegalArgumentException("status cannot be null");
+        }
+        if (undoData == null) {
+            throw new IllegalArgumentException("undoData cannot be null");
+        }
+
+        validateUndoDataCompatibility(operationType, undoData);
+
+        this.operationType = operationType;
+        this.status = status;
+        this.undoData = undoData;
+        this.targetNodeId = normalizeOptional(targetNodeId);
+        this.ownerUserId = normalizeOptional(ownerUserId);
+        this.description = normalizeOptional(description);
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public IoOperationType getOperationType() {
+        return operationType;
+    }
+
+    public String getTargetPath() {
+        return targetPath;
+    }
+
+    public JournalStatus getStatus() {
+        return status;
+    }
+
+    public JournalUndoData getUndoData() {
+        return undoData;
+    }
+
+    public String getTargetNodeId() {
+        return targetNodeId;
+    }
+
+    public String getOwnerUserId() {
+        return ownerUserId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean isPending() {
+        return status == JournalStatus.PENDING;
+    }
+
+    public boolean isCommitted() {
+        return status == JournalStatus.COMMITTED;
+    }
+
+    public boolean isUndone() {
+        return status == JournalStatus.UNDONE;
+    }
+
+    void markCommitted() {
+        transitionTo(JournalStatus.COMMITTED);
+    }
+
+    void markUndone() {
+        transitionTo(JournalStatus.UNDONE);
+    }
+
+    private void transitionTo(JournalStatus newStatus) {
+        if (newStatus == null) {
+            throw new IllegalArgumentException("newStatus cannot be null");
+        }
+        if (status != JournalStatus.PENDING) {
+            throw new IllegalStateException("only PENDING journal entries can change status");
+        }
+        if (newStatus != JournalStatus.COMMITTED && newStatus != JournalStatus.UNDONE) {
+            throw new IllegalArgumentException("PENDING entries can only transition to COMMITTED or UNDONE");
+        }
+        status = newStatus;
+    }
+
+    private static void validateUndoDataCompatibility(IoOperationType operationType, JournalUndoData undoData) {
+        switch (operationType) {
+            case CREATE -> {
+                if (!(undoData instanceof CreateFileUndoData) && !(undoData instanceof CreateDirectoryUndoData)) {
+                    throw new IllegalArgumentException("CREATE journal entries require create undo data");
+                }
+            }
+            case DELETE -> {
+                if (!(undoData instanceof DeleteFileUndoData) && !(undoData instanceof DeleteDirectoryUndoData)) {
+                    throw new IllegalArgumentException("DELETE journal entries require delete undo data");
+                }
+            }
+            case UPDATE -> {
+                if (!(undoData instanceof UpdateRenameUndoData)) {
+                    throw new IllegalArgumentException("UPDATE journal entries require rename undo data");
+                }
+            }
+            case READ -> throw new IllegalArgumentException("READ operations cannot be journaled");
+            default -> throw new IllegalArgumentException("unsupported operationType: " + operationType);
+        }
+    }
+
+    private static String requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
+        }
+        return value;
+    }
+
+    private static String normalizeOptional(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/journal/JournalManager.java
+++ b/src/main/java/ve/edu/unimet/so/project2/journal/JournalManager.java
@@ -1,0 +1,191 @@
+package ve.edu.unimet.so.project2.journal;
+
+import ve.edu.unimet.so.project2.datastructures.SimpleList;
+import ve.edu.unimet.so.project2.journal.undo.JournalUndoData;
+import ve.edu.unimet.so.project2.process.IoOperationType;
+
+public final class JournalManager {
+
+    private static final String TRANSACTION_PREFIX = "TX-";
+
+    private final SimpleList<JournalEntry> entries;
+    private long nextTransactionNumber;
+
+    public JournalManager() {
+        this.entries = new SimpleList<>();
+        this.nextTransactionNumber = 1L;
+    }
+
+    public JournalEntry registerPending(
+            IoOperationType operationType,
+            String targetPath,
+            JournalUndoData undoData) {
+        return registerPending(operationType, targetPath, undoData, null, null, null);
+    }
+
+    public JournalEntry registerPending(
+            IoOperationType operationType,
+            String targetPath,
+            JournalUndoData undoData,
+            String targetNodeId,
+            String ownerUserId,
+            String description) {
+        String transactionId = buildNextTransactionId();
+        ensureTransactionIdDoesNotExist(transactionId);
+
+        JournalEntry entry = new JournalEntry(
+                transactionId,
+                operationType,
+                targetPath,
+                JournalStatus.PENDING,
+                undoData,
+                targetNodeId,
+                ownerUserId,
+                description);
+        entries.add(entry);
+        nextTransactionNumber++;
+        return entry;
+    }
+
+    public JournalEntry restoreEntry(
+            String transactionId,
+            IoOperationType operationType,
+            String targetPath,
+            JournalStatus status,
+            JournalUndoData undoData,
+            String targetNodeId,
+            String ownerUserId,
+            String description) {
+        JournalEntry entry = new JournalEntry(
+                transactionId,
+                operationType,
+                targetPath,
+                status,
+                undoData,
+                targetNodeId,
+                ownerUserId,
+                description);
+        ensureTransactionIdDoesNotExist(entry.getTransactionId());
+        entries.add(entry);
+        advanceNextTransactionNumberFrom(entry.getTransactionId());
+        return entry;
+    }
+
+    public JournalEntry markCommitted(String transactionId) {
+        JournalEntry entry = requireExistingEntry(transactionId);
+        entry.markCommitted();
+        return entry;
+    }
+
+    public JournalEntry markUndone(String transactionId) {
+        JournalEntry entry = requireExistingEntry(transactionId);
+        entry.markUndone();
+        return entry;
+    }
+
+    public JournalEntry findByTransactionId(String transactionId) {
+        requireNonBlank(transactionId, "transactionId");
+        for (int i = 0; i < entries.size(); i++) {
+            JournalEntry entry = entries.get(i);
+            if (entry.getTransactionId().equals(transactionId)) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    public int getEntryCount() {
+        return entries.size();
+    }
+
+    public JournalEntry getEntryAt(int index) {
+        return entries.get(index);
+    }
+
+    public Object[] getEntriesSnapshot() {
+        return entries.toArray();
+    }
+
+    public int getPendingCount() {
+        return collectPendingEntries().size();
+    }
+
+    public JournalEntry getPendingEntryAt(int index) {
+        return collectPendingEntries().get(index);
+    }
+
+    public Object[] getPendingEntriesSnapshot() {
+        return collectPendingEntries().toArray();
+    }
+
+    public void clear() {
+        entries.clear();
+        nextTransactionNumber = 1L;
+    }
+
+    private SimpleList<JournalEntry> collectPendingEntries() {
+        SimpleList<JournalEntry> pendingEntries = new SimpleList<>();
+        for (int i = 0; i < entries.size(); i++) {
+            JournalEntry entry = entries.get(i);
+            if (entry.isPending()) {
+                pendingEntries.add(entry);
+            }
+        }
+        return pendingEntries;
+    }
+
+    private JournalEntry requireExistingEntry(String transactionId) {
+        JournalEntry entry = findByTransactionId(transactionId);
+        if (entry == null) {
+            throw new IllegalArgumentException("journal entry not found for transactionId: " + transactionId);
+        }
+        return entry;
+    }
+
+    private void ensureTransactionIdDoesNotExist(String transactionId) {
+        if (findByTransactionId(transactionId) != null) {
+            throw new IllegalStateException("duplicate transactionId detected: " + transactionId);
+        }
+    }
+
+    private String buildNextTransactionId() {
+        if (nextTransactionNumber <= 0) {
+            throw new IllegalStateException("nextTransactionNumber must stay positive");
+        }
+        return TRANSACTION_PREFIX + nextTransactionNumber;
+    }
+
+    private void advanceNextTransactionNumberFrom(String transactionId) {
+        if (!transactionId.startsWith(TRANSACTION_PREFIX)) {
+            return;
+        }
+
+        String suffix = transactionId.substring(TRANSACTION_PREFIX.length());
+        if (suffix.isBlank()) {
+            return;
+        }
+
+        long restoredNumber;
+        try {
+            restoredNumber = Long.parseLong(suffix);
+        } catch (NumberFormatException ignored) {
+            return;
+        }
+
+        if (restoredNumber <= 0) {
+            return;
+        }
+
+        long candidateNext = restoredNumber + 1;
+        if (candidateNext > nextTransactionNumber) {
+            nextTransactionNumber = candidateNext;
+        }
+    }
+
+    private static String requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/journal/JournalStatus.java
+++ b/src/main/java/ve/edu/unimet/so/project2/journal/JournalStatus.java
@@ -1,0 +1,7 @@
+package ve.edu.unimet.so.project2.journal;
+
+public enum JournalStatus {
+    PENDING,
+    COMMITTED,
+    UNDONE
+}

--- a/src/main/java/ve/edu/unimet/so/project2/journal/undo/CreateDirectoryUndoData.java
+++ b/src/main/java/ve/edu/unimet/so/project2/journal/undo/CreateDirectoryUndoData.java
@@ -1,0 +1,36 @@
+package ve.edu.unimet.so.project2.journal.undo;
+
+public final class CreateDirectoryUndoData implements JournalUndoData {
+
+    private final String createdDirectoryId;
+    private final String parentDirectoryId;
+    private final String parentDirectoryPath;
+
+    public CreateDirectoryUndoData(
+            String createdDirectoryId,
+            String parentDirectoryId,
+            String parentDirectoryPath) {
+        this.createdDirectoryId = requireNonBlank(createdDirectoryId, "createdDirectoryId");
+        this.parentDirectoryId = requireNonBlank(parentDirectoryId, "parentDirectoryId");
+        this.parentDirectoryPath = requireNonBlank(parentDirectoryPath, "parentDirectoryPath");
+    }
+
+    public String getCreatedDirectoryId() {
+        return createdDirectoryId;
+    }
+
+    public String getParentDirectoryId() {
+        return parentDirectoryId;
+    }
+
+    public String getParentDirectoryPath() {
+        return parentDirectoryPath;
+    }
+
+    private static String requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/journal/undo/CreateFileUndoData.java
+++ b/src/main/java/ve/edu/unimet/so/project2/journal/undo/CreateFileUndoData.java
@@ -1,0 +1,69 @@
+package ve.edu.unimet.so.project2.journal.undo;
+
+public final class CreateFileUndoData implements JournalUndoData {
+
+    private final String createdFileId;
+    private final String parentDirectoryId;
+    private final String parentDirectoryPath;
+    private final int[] allocatedBlockIndexes;
+
+    public CreateFileUndoData(
+            String createdFileId,
+            String parentDirectoryId,
+            String parentDirectoryPath,
+            int[] allocatedBlockIndexes) {
+        this.createdFileId = requireNonBlank(createdFileId, "createdFileId");
+        this.parentDirectoryId = requireNonBlank(parentDirectoryId, "parentDirectoryId");
+        this.parentDirectoryPath = requireNonBlank(parentDirectoryPath, "parentDirectoryPath");
+        this.allocatedBlockIndexes = copyAndValidateBlockIndexes(allocatedBlockIndexes);
+    }
+
+    public String getCreatedFileId() {
+        return createdFileId;
+    }
+
+    public String getParentDirectoryId() {
+        return parentDirectoryId;
+    }
+
+    public String getParentDirectoryPath() {
+        return parentDirectoryPath;
+    }
+
+    public int getAllocatedBlockCount() {
+        return allocatedBlockIndexes.length;
+    }
+
+    public int getAllocatedBlockIndexAt(int index) {
+        return allocatedBlockIndexes[index];
+    }
+
+    public int[] getAllocatedBlockIndexesSnapshot() {
+        return allocatedBlockIndexes.clone();
+    }
+
+    private static int[] copyAndValidateBlockIndexes(int[] source) {
+        if (source == null || source.length == 0) {
+            throw new IllegalArgumentException("allocatedBlockIndexes cannot be null or empty");
+        }
+        int[] copy = source.clone();
+        for (int i = 0; i < copy.length; i++) {
+            if (copy[i] < 0) {
+                throw new IllegalArgumentException("allocated block indexes cannot be negative");
+            }
+            for (int j = i + 1; j < copy.length; j++) {
+                if (copy[i] == copy[j]) {
+                    throw new IllegalArgumentException("allocatedBlockIndexes cannot repeat block ids");
+                }
+            }
+        }
+        return copy;
+    }
+
+    private static String requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/journal/undo/DeleteDirectoryUndoData.java
+++ b/src/main/java/ve/edu/unimet/so/project2/journal/undo/DeleteDirectoryUndoData.java
@@ -1,0 +1,144 @@
+package ve.edu.unimet.so.project2.journal.undo;
+
+import ve.edu.unimet.so.project2.filesystem.FsNodeType;
+
+public final class DeleteDirectoryUndoData implements JournalUndoData {
+
+    private final String deletedDirectoryId;
+    private final String parentDirectoryId;
+    private final String parentDirectoryPath;
+    private final JournalNodeSnapshot[] subtreeNodeSnapshots;
+    private final JournalBlockSnapshot[] associatedBlockSnapshots;
+
+    public DeleteDirectoryUndoData(
+            String deletedDirectoryId,
+            String parentDirectoryId,
+            String parentDirectoryPath,
+            JournalNodeSnapshot[] subtreeNodeSnapshots,
+            JournalBlockSnapshot[] associatedBlockSnapshots) {
+        this.deletedDirectoryId = requireNonBlank(deletedDirectoryId, "deletedDirectoryId");
+        this.parentDirectoryId = requireNonBlank(parentDirectoryId, "parentDirectoryId");
+        this.parentDirectoryPath = requireNonBlank(parentDirectoryPath, "parentDirectoryPath");
+        this.subtreeNodeSnapshots = copyAndValidateNodeSnapshots(subtreeNodeSnapshots, this.deletedDirectoryId);
+        validateRootParentConsistency(this.deletedDirectoryId, this.parentDirectoryId, this.parentDirectoryPath, this.subtreeNodeSnapshots);
+        this.associatedBlockSnapshots = copyAndValidateBlockSnapshots(
+                associatedBlockSnapshots,
+                this.deletedDirectoryId,
+                this.subtreeNodeSnapshots);
+    }
+
+    public String getDeletedDirectoryId() {
+        return deletedDirectoryId;
+    }
+
+    public String getParentDirectoryId() {
+        return parentDirectoryId;
+    }
+
+    public String getParentDirectoryPath() {
+        return parentDirectoryPath;
+    }
+
+    public int getSubtreeNodeCount() {
+        return subtreeNodeSnapshots.length;
+    }
+
+    public JournalNodeSnapshot getSubtreeNodeSnapshotAt(int index) {
+        return subtreeNodeSnapshots[index];
+    }
+
+    public JournalNodeSnapshot[] getSubtreeNodeSnapshotsSnapshot() {
+        return subtreeNodeSnapshots.clone();
+    }
+
+    public int getAssociatedBlockCount() {
+        return associatedBlockSnapshots.length;
+    }
+
+    public JournalBlockSnapshot getAssociatedBlockSnapshotAt(int index) {
+        return associatedBlockSnapshots[index];
+    }
+
+    public JournalBlockSnapshot[] getAssociatedBlockSnapshotsSnapshot() {
+        return associatedBlockSnapshots.clone();
+    }
+
+    private static JournalNodeSnapshot[] copyAndValidateNodeSnapshots(
+            JournalNodeSnapshot[] source,
+            String deletedDirectoryId) {
+        if (source == null || source.length == 0) {
+            throw new IllegalArgumentException("subtreeNodeSnapshots cannot be null or empty");
+        }
+        JournalNodeSnapshot[] copy = source.clone();
+        boolean containsDeletedDirectory = false;
+        for (JournalNodeSnapshot snapshot : copy) {
+            if (snapshot == null) {
+                throw new IllegalArgumentException("subtreeNodeSnapshots cannot contain null entries");
+            }
+            if (snapshot.getNodeId().equals(deletedDirectoryId)
+                    && snapshot.getNodeType() == FsNodeType.DIRECTORY) {
+                containsDeletedDirectory = true;
+            }
+        }
+        if (!containsDeletedDirectory) {
+            throw new IllegalArgumentException("subtree snapshots must include the deleted directory root");
+        }
+        return copy;
+    }
+
+    private static void validateRootParentConsistency(
+            String deletedDirectoryId,
+            String parentDirectoryId,
+            String parentDirectoryPath,
+            JournalNodeSnapshot[] subtreeNodeSnapshots) {
+        JournalNodeSnapshot deletedRoot = findDeletedRootSnapshot(deletedDirectoryId, subtreeNodeSnapshots);
+        if (!parentDirectoryId.equals(deletedRoot.getParentNodeId())) {
+            throw new IllegalArgumentException("parentDirectoryId must match the deleted root parentNodeId");
+        }
+
+        String expectedParentPath = deriveParentPath(deletedRoot.getNodePath());
+        if (!parentDirectoryPath.equals(expectedParentPath)) {
+            throw new IllegalArgumentException("parentDirectoryPath must match the parent path derived from the deleted root snapshot");
+        }
+    }
+
+    private static JournalBlockSnapshot[] copyAndValidateBlockSnapshots(
+            JournalBlockSnapshot[] source,
+            String deletedDirectoryId,
+            JournalNodeSnapshot[] subtreeNodeSnapshots) {
+        if (source == null) {
+            throw new IllegalArgumentException("associatedBlockSnapshots cannot be null");
+        }
+        JournalBlockSnapshot[] copy = source.clone();
+        JournalUndoValidation.validateDeletedDirectorySubtree(deletedDirectoryId, subtreeNodeSnapshots, copy);
+        return copy;
+    }
+
+    private static JournalNodeSnapshot findDeletedRootSnapshot(
+            String deletedDirectoryId,
+            JournalNodeSnapshot[] subtreeNodeSnapshots) {
+        for (JournalNodeSnapshot snapshot : subtreeNodeSnapshots) {
+            if (snapshot != null
+                    && snapshot.getNodeId().equals(deletedDirectoryId)
+                    && snapshot.isDirectory()) {
+                return snapshot;
+            }
+        }
+        throw new IllegalArgumentException("subtree snapshots must include the deleted directory root");
+    }
+
+    private static String deriveParentPath(String nodePath) {
+        int lastSlash = nodePath.lastIndexOf('/');
+        if (lastSlash <= 0) {
+            return "/";
+        }
+        return nodePath.substring(0, lastSlash);
+    }
+
+    private static String requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/journal/undo/DeleteFileUndoData.java
+++ b/src/main/java/ve/edu/unimet/so/project2/journal/undo/DeleteFileUndoData.java
@@ -1,0 +1,91 @@
+package ve.edu.unimet.so.project2.journal.undo;
+
+public final class DeleteFileUndoData implements JournalUndoData {
+
+    private final JournalNodeSnapshot deletedFileSnapshot;
+    private final String parentDirectoryId;
+    private final String parentDirectoryPath;
+    private final JournalBlockSnapshot[] blockChainSnapshots;
+
+    public DeleteFileUndoData(
+            JournalNodeSnapshot deletedFileSnapshot,
+            String parentDirectoryId,
+            String parentDirectoryPath,
+            JournalBlockSnapshot[] blockChainSnapshots) {
+        if (deletedFileSnapshot == null) {
+            throw new IllegalArgumentException("deletedFileSnapshot cannot be null");
+        }
+        if (!deletedFileSnapshot.isFile()) {
+            throw new IllegalArgumentException("deletedFileSnapshot must represent a file");
+        }
+        this.parentDirectoryId = requireNonBlank(parentDirectoryId, "parentDirectoryId");
+        this.parentDirectoryPath = requireNonBlank(parentDirectoryPath, "parentDirectoryPath");
+        validateParentConsistency(deletedFileSnapshot, this.parentDirectoryId, this.parentDirectoryPath);
+        this.blockChainSnapshots = copyAndValidateBlockSnapshots(blockChainSnapshots, deletedFileSnapshot);
+        this.deletedFileSnapshot = deletedFileSnapshot;
+    }
+
+    public JournalNodeSnapshot getDeletedFileSnapshot() {
+        return deletedFileSnapshot;
+    }
+
+    public String getParentDirectoryId() {
+        return parentDirectoryId;
+    }
+
+    public String getParentDirectoryPath() {
+        return parentDirectoryPath;
+    }
+
+    public int getBlockChainLength() {
+        return blockChainSnapshots.length;
+    }
+
+    public JournalBlockSnapshot getBlockSnapshotAt(int index) {
+        return blockChainSnapshots[index];
+    }
+
+    public JournalBlockSnapshot[] getBlockChainSnapshotsSnapshot() {
+        return blockChainSnapshots.clone();
+    }
+
+    private static JournalBlockSnapshot[] copyAndValidateBlockSnapshots(
+            JournalBlockSnapshot[] source,
+            JournalNodeSnapshot deletedFileSnapshot) {
+        if (source == null || source.length == 0) {
+            throw new IllegalArgumentException("blockChainSnapshots cannot be null or empty");
+        }
+        JournalBlockSnapshot[] copy = source.clone();
+        JournalUndoValidation.validateDeletedFileChain(deletedFileSnapshot, copy);
+        return copy;
+    }
+
+    private static void validateParentConsistency(
+            JournalNodeSnapshot deletedFileSnapshot,
+            String parentDirectoryId,
+            String parentDirectoryPath) {
+        if (!parentDirectoryId.equals(deletedFileSnapshot.getParentNodeId())) {
+            throw new IllegalArgumentException("parentDirectoryId must match deletedFileSnapshot parentNodeId");
+        }
+
+        String expectedParentPath = deriveParentPath(deletedFileSnapshot.getNodePath());
+        if (!parentDirectoryPath.equals(expectedParentPath)) {
+            throw new IllegalArgumentException("parentDirectoryPath must match the parent path derived from deletedFileSnapshot");
+        }
+    }
+
+    private static String deriveParentPath(String nodePath) {
+        int lastSlash = nodePath.lastIndexOf('/');
+        if (lastSlash <= 0) {
+            return "/";
+        }
+        return nodePath.substring(0, lastSlash);
+    }
+
+    private static String requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/journal/undo/JournalBlockSnapshot.java
+++ b/src/main/java/ve/edu/unimet/so/project2/journal/undo/JournalBlockSnapshot.java
@@ -1,0 +1,50 @@
+package ve.edu.unimet.so.project2.journal.undo;
+
+public final class JournalBlockSnapshot {
+
+    public static final int NO_NEXT_BLOCK = -1;
+
+    private final int index;
+    private final String ownerFileId;
+    private final int nextBlockIndex;
+    private final boolean systemReserved;
+
+    public JournalBlockSnapshot(int index, String ownerFileId, int nextBlockIndex, boolean systemReserved) {
+        if (index < 0) {
+            throw new IllegalArgumentException("index cannot be negative");
+        }
+        this.ownerFileId = requireNonBlank(ownerFileId, "ownerFileId");
+        if (nextBlockIndex < NO_NEXT_BLOCK) {
+            throw new IllegalArgumentException("nextBlockIndex cannot be less than NO_NEXT_BLOCK");
+        }
+        if (nextBlockIndex == index) {
+            throw new IllegalArgumentException("block snapshot cannot point to itself");
+        }
+        this.index = index;
+        this.nextBlockIndex = nextBlockIndex;
+        this.systemReserved = systemReserved;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public String getOwnerFileId() {
+        return ownerFileId;
+    }
+
+    public int getNextBlockIndex() {
+        return nextBlockIndex;
+    }
+
+    public boolean isSystemReserved() {
+        return systemReserved;
+    }
+
+    private static String requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/journal/undo/JournalNodeSnapshot.java
+++ b/src/main/java/ve/edu/unimet/so/project2/journal/undo/JournalNodeSnapshot.java
@@ -1,0 +1,213 @@
+package ve.edu.unimet.so.project2.journal.undo;
+
+import ve.edu.unimet.so.project2.filesystem.FsNodeType;
+
+public final class JournalNodeSnapshot {
+
+    public static final int NO_BLOCK = -1;
+
+    private final String nodeId;
+    private final FsNodeType nodeType;
+    private final String name;
+    private final String ownerUserId;
+    private final String parentNodeId;
+    private final String nodePath;
+    private final boolean publicReadable;
+    private final int sizeInBlocks;
+    private final int firstBlockIndex;
+    private final String colorId;
+    private final boolean systemFile;
+    private final boolean root;
+
+    public JournalNodeSnapshot(
+            String nodeId,
+            FsNodeType nodeType,
+            String name,
+            String ownerUserId,
+            String parentNodeId,
+            String nodePath,
+            boolean publicReadable,
+            int sizeInBlocks,
+            int firstBlockIndex,
+            String colorId,
+            boolean systemFile) {
+        this.nodeId = requireNonBlank(nodeId, "nodeId");
+        if (nodeType == null) {
+            throw new IllegalArgumentException("nodeType cannot be null");
+        }
+        this.root = validateSnapshotIdentity(nodeType, name, parentNodeId, nodePath);
+        this.ownerUserId = requireNonBlank(ownerUserId, "ownerUserId");
+        this.parentNodeId = root ? null : requireNonBlank(parentNodeId, "parentNodeId");
+        this.nodePath = requireNonBlank(nodePath, "nodePath");
+        this.colorId = normalizeOptional(colorId);
+        validateNodeSpecificFields(nodeType, sizeInBlocks, firstBlockIndex, this.colorId);
+
+        this.nodeType = nodeType;
+        this.name = name;
+        this.publicReadable = publicReadable;
+        this.sizeInBlocks = sizeInBlocks;
+        this.firstBlockIndex = firstBlockIndex;
+        this.systemFile = systemFile;
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public FsNodeType getNodeType() {
+        return nodeType;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getOwnerUserId() {
+        return ownerUserId;
+    }
+
+    public String getParentNodeId() {
+        return parentNodeId;
+    }
+
+    public String getNodePath() {
+        return nodePath;
+    }
+
+    public boolean isPublicReadable() {
+        return publicReadable;
+    }
+
+    public int getSizeInBlocks() {
+        return sizeInBlocks;
+    }
+
+    public int getFirstBlockIndex() {
+        return firstBlockIndex;
+    }
+
+    public String getColorId() {
+        return colorId;
+    }
+
+    public boolean isSystemFile() {
+        return systemFile;
+    }
+
+    public boolean isFile() {
+        return nodeType == FsNodeType.FILE;
+    }
+
+    public boolean isDirectory() {
+        return nodeType == FsNodeType.DIRECTORY;
+    }
+
+    public boolean isRoot() {
+        return root;
+    }
+
+    private static void validateNodeSpecificFields(
+            FsNodeType nodeType,
+            int sizeInBlocks,
+            int firstBlockIndex,
+            String colorId) {
+        if (nodeType == FsNodeType.FILE) {
+            if (sizeInBlocks <= 0) {
+                throw new IllegalArgumentException("file snapshots must keep a positive sizeInBlocks");
+            }
+            if (firstBlockIndex < 0) {
+                throw new IllegalArgumentException("file snapshots must keep a valid firstBlockIndex");
+            }
+            return;
+        }
+
+        if (sizeInBlocks != 0) {
+            throw new IllegalArgumentException("directory snapshots must use sizeInBlocks == 0");
+        }
+        if (firstBlockIndex != NO_BLOCK) {
+            throw new IllegalArgumentException("directory snapshots must use NO_BLOCK as firstBlockIndex");
+        }
+        if (colorId != null) {
+            throw new IllegalArgumentException("directory snapshots must not keep a colorId");
+        }
+    }
+
+    private static boolean validateSnapshotIdentity(
+            FsNodeType nodeType,
+            String name,
+            String parentNodeId,
+            String nodePath) {
+        if ("/".equals(name)) {
+            if (nodeType != FsNodeType.DIRECTORY) {
+                throw new IllegalArgumentException("only directories can use / as name");
+            }
+            if (!"/".equals(nodePath)) {
+                throw new IllegalArgumentException("root snapshots must use / as nodePath");
+            }
+            if (parentNodeId != null && !parentNodeId.isBlank()) {
+                throw new IllegalArgumentException("root snapshots must not declare a parentNodeId");
+            }
+            return true;
+        }
+
+        validateRegularNodeName(name);
+        requireNonBlank(parentNodeId, "parentNodeId");
+        validateCanonicalNonRootPath(name, nodePath);
+        return false;
+    }
+
+    private static void validateRegularNodeName(String value) {
+        requireNonBlank(value, "name");
+        if (value.contains("/")) {
+            throw new IllegalArgumentException("name cannot contain /");
+        }
+        if (".".equals(value) || "..".equals(value)) {
+            throw new IllegalArgumentException("name cannot be . or ..");
+        }
+    }
+
+    private static void validateCanonicalNonRootPath(String name, String nodePath) {
+        requireNonBlank(nodePath, "nodePath");
+        if (!nodePath.startsWith("/")) {
+            throw new IllegalArgumentException("non-root nodePath must start with /");
+        }
+        if ("/".equals(nodePath)) {
+            throw new IllegalArgumentException("only root snapshots can use / as nodePath");
+        }
+        if (nodePath.endsWith("/")) {
+            throw new IllegalArgumentException("non-root nodePath must not end with /");
+        }
+        if (nodePath.contains("//")) {
+            throw new IllegalArgumentException("nodePath must not contain empty path segments");
+        }
+        if (nodePath.contains("/./") || nodePath.endsWith("/.") || nodePath.contains("/../") || nodePath.endsWith("/..")) {
+            throw new IllegalArgumentException("nodePath must not contain . or .. path segments");
+        }
+
+        int lastSlash = nodePath.lastIndexOf('/');
+        if (lastSlash < 0) {
+            throw new IllegalArgumentException("nodePath must contain at least one /");
+        }
+
+        String lastSegment = nodePath.substring(lastSlash + 1);
+        if (!name.equals(lastSegment)) {
+            throw new IllegalArgumentException("nodePath must end with the snapshot name");
+        }
+    }
+
+    private static String requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
+        }
+        return value;
+    }
+
+    private static String normalizeOptional(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+}

--- a/src/main/java/ve/edu/unimet/so/project2/journal/undo/JournalUndoData.java
+++ b/src/main/java/ve/edu/unimet/so/project2/journal/undo/JournalUndoData.java
@@ -1,0 +1,4 @@
+package ve.edu.unimet.so.project2.journal.undo;
+
+public interface JournalUndoData {
+}

--- a/src/main/java/ve/edu/unimet/so/project2/journal/undo/JournalUndoValidation.java
+++ b/src/main/java/ve/edu/unimet/so/project2/journal/undo/JournalUndoValidation.java
@@ -1,0 +1,303 @@
+package ve.edu.unimet.so.project2.journal.undo;
+
+final class JournalUndoValidation {
+
+    private JournalUndoValidation() {
+    }
+
+    static void validateDeletedFileChain(
+            JournalNodeSnapshot fileSnapshot,
+            JournalBlockSnapshot[] blockSnapshots) {
+        if (fileSnapshot == null) {
+            throw new IllegalArgumentException("fileSnapshot cannot be null");
+        }
+        if (!fileSnapshot.isFile()) {
+            throw new IllegalArgumentException("fileSnapshot must represent a file");
+        }
+        if (blockSnapshots == null || blockSnapshots.length == 0) {
+            throw new IllegalArgumentException("blockSnapshots cannot be null or empty");
+        }
+        if (blockSnapshots.length != fileSnapshot.getSizeInBlocks()) {
+            throw new IllegalArgumentException("blockSnapshots must match the file sizeInBlocks");
+        }
+
+        validateUniqueBlockIndexes(blockSnapshots, "blockSnapshots");
+
+        for (JournalBlockSnapshot snapshot : blockSnapshots) {
+            if (snapshot == null) {
+                throw new IllegalArgumentException("blockSnapshots cannot contain null entries");
+            }
+            if (!snapshot.getOwnerFileId().equals(fileSnapshot.getNodeId())) {
+                throw new IllegalArgumentException("all block snapshots must belong to the deleted file");
+            }
+        }
+
+        JournalBlockSnapshot current = findBlockByIndex(blockSnapshots, fileSnapshot.getFirstBlockIndex());
+        if (current == null) {
+            throw new IllegalArgumentException("blockSnapshots must include the firstBlockIndex of the deleted file");
+        }
+
+        int visited = 0;
+        while (true) {
+            visited++;
+            if (visited > blockSnapshots.length) {
+                throw new IllegalArgumentException("block chain contains a cycle or extra indirection");
+            }
+            if (current.getNextBlockIndex() == JournalBlockSnapshot.NO_NEXT_BLOCK) {
+                break;
+            }
+
+            JournalBlockSnapshot next = findBlockByIndex(blockSnapshots, current.getNextBlockIndex());
+            if (next == null) {
+                throw new IllegalArgumentException("block chain is missing an intermediate or tail block");
+            }
+            current = next;
+        }
+
+        if (visited != blockSnapshots.length) {
+            throw new IllegalArgumentException("blockSnapshots must describe the complete deleted-file chain");
+        }
+    }
+
+    static void validateDeletedDirectorySubtree(
+            String deletedDirectoryId,
+            JournalNodeSnapshot[] subtreeNodeSnapshots,
+            JournalBlockSnapshot[] associatedBlockSnapshots) {
+        if (subtreeNodeSnapshots == null || subtreeNodeSnapshots.length == 0) {
+            throw new IllegalArgumentException("subtreeNodeSnapshots cannot be null or empty");
+        }
+        if (associatedBlockSnapshots == null) {
+            throw new IllegalArgumentException("associatedBlockSnapshots cannot be null");
+        }
+
+        validateUniqueNodeIds(subtreeNodeSnapshots);
+        validateUniqueBlockIndexes(associatedBlockSnapshots, "associatedBlockSnapshots");
+        validateSubtreeContainment(deletedDirectoryId, subtreeNodeSnapshots);
+        validateSubtreePathsMatchHierarchy(deletedDirectoryId, subtreeNodeSnapshots);
+        validateSiblingNameUniqueness(subtreeNodeSnapshots);
+        validateAssociatedBlocksBelongToSubtreeFiles(subtreeNodeSnapshots, associatedBlockSnapshots);
+        validateEachDeletedFileHasACompleteChain(subtreeNodeSnapshots, associatedBlockSnapshots);
+    }
+
+    private static void validateSubtreeContainment(String deletedDirectoryId, JournalNodeSnapshot[] subtreeNodeSnapshots) {
+        JournalNodeSnapshot deletedRoot = findNodeById(subtreeNodeSnapshots, deletedDirectoryId);
+        if (deletedRoot == null || !deletedRoot.isDirectory()) {
+            throw new IllegalArgumentException("the deleted subtree root must exist and be a directory");
+        }
+        validateDeletedRootParentBoundary(deletedRoot, subtreeNodeSnapshots);
+
+        for (JournalNodeSnapshot snapshot : subtreeNodeSnapshots) {
+            if (snapshot == null) {
+                throw new IllegalArgumentException("subtreeNodeSnapshots cannot contain null entries");
+            }
+
+            if (snapshot.getNodeId().equals(deletedDirectoryId)) {
+                if (!snapshot.isDirectory()) {
+                    throw new IllegalArgumentException("the deleted subtree root must be a directory");
+                }
+                continue;
+            }
+
+            String parentNodeId = snapshot.getParentNodeId();
+            if (parentNodeId == null) {
+                throw new IllegalArgumentException("subtree child snapshots must keep a valid parentNodeId");
+            }
+            JournalNodeSnapshot parentSnapshot = findNodeById(subtreeNodeSnapshots, parentNodeId);
+            if (parentSnapshot == null) {
+                throw new IllegalArgumentException("subtree child snapshots must point to parents inside the same subtree");
+            }
+            if (!parentSnapshot.isDirectory()) {
+                throw new IllegalArgumentException("subtree child snapshots must point only to directory parents");
+            }
+            ensureNodeReachesDeletedRoot(snapshot, deletedDirectoryId, subtreeNodeSnapshots);
+        }
+    }
+
+    private static void validateDeletedRootParentBoundary(
+            JournalNodeSnapshot deletedRoot,
+            JournalNodeSnapshot[] subtreeNodeSnapshots) {
+        if (deletedRoot.getParentNodeId() == null) {
+            throw new IllegalArgumentException("the deleted subtree root must keep a valid external parentNodeId");
+        }
+        if (findNodeById(subtreeNodeSnapshots, deletedRoot.getParentNodeId()) != null) {
+            throw new IllegalArgumentException("the deleted subtree root cannot point to a parent inside the deleted subtree");
+        }
+    }
+
+    private static void ensureNodeReachesDeletedRoot(
+            JournalNodeSnapshot startNode,
+            String deletedDirectoryId,
+            JournalNodeSnapshot[] subtreeNodeSnapshots) {
+        JournalNodeSnapshot current = startNode;
+        int traversed = 0;
+
+        while (!current.getNodeId().equals(deletedDirectoryId)) {
+            traversed++;
+            if (traversed > subtreeNodeSnapshots.length) {
+                throw new IllegalArgumentException("subtreeNodeSnapshots must form a single tree rooted at the deleted directory");
+            }
+
+            String parentNodeId = current.getParentNodeId();
+            if (parentNodeId == null) {
+                throw new IllegalArgumentException("subtree child snapshots must keep a valid parentNodeId");
+            }
+
+            current = findNodeById(subtreeNodeSnapshots, parentNodeId);
+            if (current == null) {
+                throw new IllegalArgumentException("subtree child snapshots must point to parents inside the same subtree");
+            }
+            if (!current.isDirectory()) {
+                throw new IllegalArgumentException("subtree child snapshots must point only to directory parents");
+            }
+        }
+    }
+
+    private static void validateAssociatedBlocksBelongToSubtreeFiles(
+            JournalNodeSnapshot[] subtreeNodeSnapshots,
+            JournalBlockSnapshot[] associatedBlockSnapshots) {
+        for (JournalBlockSnapshot blockSnapshot : associatedBlockSnapshots) {
+            if (blockSnapshot == null) {
+                throw new IllegalArgumentException("associatedBlockSnapshots cannot contain null entries");
+            }
+
+            JournalNodeSnapshot ownerFile = findNodeById(subtreeNodeSnapshots, blockSnapshot.getOwnerFileId());
+            if (ownerFile == null || !ownerFile.isFile()) {
+                throw new IllegalArgumentException("every associated block must belong to a file inside the deleted subtree");
+            }
+        }
+    }
+
+    private static void validateSubtreePathsMatchHierarchy(
+            String deletedDirectoryId,
+            JournalNodeSnapshot[] subtreeNodeSnapshots) {
+        for (JournalNodeSnapshot snapshot : subtreeNodeSnapshots) {
+            if (snapshot == null || snapshot.getNodeId().equals(deletedDirectoryId)) {
+                continue;
+            }
+
+            JournalNodeSnapshot parentSnapshot = findNodeById(subtreeNodeSnapshots, snapshot.getParentNodeId());
+            if (parentSnapshot == null) {
+                throw new IllegalArgumentException("subtree child snapshots must point to parents inside the same subtree");
+            }
+
+            String expectedPath = deriveChildPath(parentSnapshot.getNodePath(), snapshot.getName());
+            if (!expectedPath.equals(snapshot.getNodePath())) {
+                throw new IllegalArgumentException("subtree node paths must match the parent hierarchy and node name");
+            }
+        }
+    }
+
+    private static void validateSiblingNameUniqueness(JournalNodeSnapshot[] subtreeNodeSnapshots) {
+        for (int i = 0; i < subtreeNodeSnapshots.length; i++) {
+            JournalNodeSnapshot left = subtreeNodeSnapshots[i];
+            if (left == null || left.getParentNodeId() == null) {
+                continue;
+            }
+
+            for (int j = i + 1; j < subtreeNodeSnapshots.length; j++) {
+                JournalNodeSnapshot right = subtreeNodeSnapshots[j];
+                if (right == null || right.getParentNodeId() == null) {
+                    continue;
+                }
+                if (left.getParentNodeId().equals(right.getParentNodeId())
+                        && left.getName().equals(right.getName())) {
+                    throw new IllegalArgumentException(
+                            "subtreeNodeSnapshots cannot contain duplicate sibling names under the same parent");
+                }
+            }
+        }
+    }
+
+    private static void validateEachDeletedFileHasACompleteChain(
+            JournalNodeSnapshot[] subtreeNodeSnapshots,
+            JournalBlockSnapshot[] associatedBlockSnapshots) {
+        for (JournalNodeSnapshot snapshot : subtreeNodeSnapshots) {
+            if (!snapshot.isFile()) {
+                continue;
+            }
+            JournalBlockSnapshot[] fileBlocks = collectBlocksForOwner(associatedBlockSnapshots, snapshot.getNodeId());
+            validateDeletedFileChain(snapshot, fileBlocks);
+        }
+    }
+
+    private static JournalBlockSnapshot[] collectBlocksForOwner(
+            JournalBlockSnapshot[] associatedBlockSnapshots,
+            String ownerFileId) {
+        int matchCount = 0;
+        for (JournalBlockSnapshot snapshot : associatedBlockSnapshots) {
+            if (snapshot.getOwnerFileId().equals(ownerFileId)) {
+                matchCount++;
+            }
+        }
+
+        JournalBlockSnapshot[] matches = new JournalBlockSnapshot[matchCount];
+        int nextIndex = 0;
+        for (JournalBlockSnapshot snapshot : associatedBlockSnapshots) {
+            if (snapshot.getOwnerFileId().equals(ownerFileId)) {
+                matches[nextIndex++] = snapshot;
+            }
+        }
+        return matches;
+    }
+
+    private static JournalNodeSnapshot findNodeById(JournalNodeSnapshot[] snapshots, String nodeId) {
+        for (JournalNodeSnapshot snapshot : snapshots) {
+            if (snapshot != null && snapshot.getNodeId().equals(nodeId)) {
+                return snapshot;
+            }
+        }
+        return null;
+    }
+
+    private static JournalBlockSnapshot findBlockByIndex(JournalBlockSnapshot[] snapshots, int blockIndex) {
+        for (JournalBlockSnapshot snapshot : snapshots) {
+            if (snapshot != null && snapshot.getIndex() == blockIndex) {
+                return snapshot;
+            }
+        }
+        return null;
+    }
+
+    private static String deriveChildPath(String parentPath, String childName) {
+        if ("/".equals(parentPath)) {
+            return "/" + childName;
+        }
+        return parentPath + "/" + childName;
+    }
+
+    private static void validateUniqueNodeIds(JournalNodeSnapshot[] snapshots) {
+        for (int i = 0; i < snapshots.length; i++) {
+            JournalNodeSnapshot left = snapshots[i];
+            if (left == null) {
+                throw new IllegalArgumentException("subtreeNodeSnapshots cannot contain null entries");
+            }
+            for (int j = i + 1; j < snapshots.length; j++) {
+                JournalNodeSnapshot right = snapshots[j];
+                if (right == null) {
+                    throw new IllegalArgumentException("subtreeNodeSnapshots cannot contain null entries");
+                }
+                if (left.getNodeId().equals(right.getNodeId())) {
+                    throw new IllegalArgumentException("subtreeNodeSnapshots cannot repeat node ids");
+                }
+            }
+        }
+    }
+
+    private static void validateUniqueBlockIndexes(JournalBlockSnapshot[] snapshots, String fieldName) {
+        for (int i = 0; i < snapshots.length; i++) {
+            JournalBlockSnapshot left = snapshots[i];
+            if (left == null) {
+                throw new IllegalArgumentException(fieldName + " cannot contain null entries");
+            }
+            for (int j = i + 1; j < snapshots.length; j++) {
+                JournalBlockSnapshot right = snapshots[j];
+                if (right == null) {
+                    throw new IllegalArgumentException(fieldName + " cannot contain null entries");
+                }
+                if (left.getIndex() == right.getIndex()) {
+                    throw new IllegalArgumentException(fieldName + " cannot repeat block indexes");
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/journal/undo/UpdateRenameUndoData.java
+++ b/src/main/java/ve/edu/unimet/so/project2/journal/undo/UpdateRenameUndoData.java
@@ -1,0 +1,65 @@
+package ve.edu.unimet.so.project2.journal.undo;
+
+public final class UpdateRenameUndoData implements JournalUndoData {
+
+    private final String targetNodeId;
+    private final String parentDirectoryId;
+    private final String parentDirectoryPath;
+    private final String oldName;
+    private final String newName;
+
+    public UpdateRenameUndoData(
+            String targetNodeId,
+            String parentDirectoryId,
+            String parentDirectoryPath,
+            String oldName,
+            String newName) {
+        this.targetNodeId = requireNonBlank(targetNodeId, "targetNodeId");
+        this.parentDirectoryId = requireNonBlank(parentDirectoryId, "parentDirectoryId");
+        this.parentDirectoryPath = requireNonBlank(parentDirectoryPath, "parentDirectoryPath");
+        validateNodeName(oldName, "oldName");
+        validateNodeName(newName, "newName");
+        if (oldName.equals(newName)) {
+            throw new IllegalArgumentException("oldName and newName must be different");
+        }
+        this.oldName = oldName;
+        this.newName = newName;
+    }
+
+    public String getTargetNodeId() {
+        return targetNodeId;
+    }
+
+    public String getParentDirectoryId() {
+        return parentDirectoryId;
+    }
+
+    public String getParentDirectoryPath() {
+        return parentDirectoryPath;
+    }
+
+    public String getOldName() {
+        return oldName;
+    }
+
+    public String getNewName() {
+        return newName;
+    }
+
+    private static void validateNodeName(String value, String fieldName) {
+        requireNonBlank(value, fieldName);
+        if (value.contains("/")) {
+            throw new IllegalArgumentException(fieldName + " cannot contain /");
+        }
+        if (".".equals(value) || "..".equals(value)) {
+            throw new IllegalArgumentException(fieldName + " cannot be . or ..");
+        }
+    }
+
+    private static String requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/locking/FileLockState.java
+++ b/src/main/java/ve/edu/unimet/so/project2/locking/FileLockState.java
@@ -107,7 +107,7 @@ final class FileLockState {
                     new SimpleList<>());
         }
 
-        if (shouldBlockBehindQueueOrPendingGrants(requestedLockType)) {
+        if (shouldBlockBehindQueueOrPendingGrants()) {
             return enqueueBlocked(processId, requestedLockType, findBlockingProcessIdForNewArrival(processId));
         }
 
@@ -165,7 +165,7 @@ final class FileLockState {
         return false;
     }
 
-    private boolean shouldBlockBehindQueueOrPendingGrants(LockType requestedLockType) {
+    private boolean shouldBlockBehindQueueOrPendingGrants() {
         if (hasPendingGrants()) {
             return true;
         }
@@ -264,14 +264,12 @@ final class FileLockState {
     }
 
     private String findOlderPendingGrantProcessId(String requesterProcessId) {
-        for (int i = 0; i < pendingGrants.size(); i++) {
-            String pendingOwner = pendingGrants.get(i).getProcessId();
-            if (pendingOwner.equals(requesterProcessId)) {
-                return null;
-            }
-            return pendingOwner;
+        if (pendingGrants.isEmpty()) {
+            return null;
         }
-        return null;
+
+        String firstPendingOwner = pendingGrants.get(0).getProcessId();
+        return firstPendingOwner.equals(requesterProcessId) ? null : firstPendingOwner;
     }
 
     private String findNonRequesterPendingGrantProcessId(String requesterProcessId) {


### PR DESCRIPTION
Adds the journal foundation layer for critical filesystem operations.

Included in this PR:
- `JournalStatus`
- `JournalEntry`
- `JournalManager`
- immutable undo payloads under `journal/undo`
- snapshot validation for deleted files, deleted subtrees, and rename rollback data
- restore API for rehydrating persisted journal entries

Key behaviors covered:
- strict journal status transitions
- deterministic transaction id generation
- rejection of invalid journaled operations such as `READ`
- immutable undo data with no live filesystem/disk references
- subtree, parent, path, and block-chain consistency validation
- support for restoring persisted entries without regenerating ids

This PR intentionally does not include:
- coordinator integration
- real undo execution against filesystem/disk
- persistence serialization/deserialization
- GUI integration

This establishes the journal-domain foundation required for crash recovery, persistence, and later coordinator wiring.