### PR TITLE
feat: implement coordinator and scheduler foundations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /build/
 /dist/
 /out/
+/out-review/
+/out-review-current/
 
 
 # OS junk

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,17 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>22</maven.compiler.source>
         <maven.compiler.target>22</maven.compiler.target>
+        <junit.jupiter.version>5.10.2</junit.jupiter.version>
         <exec.mainClass>ve.edu.unimet.so.project2.project2os.Project2OS</exec.mainClass>
     </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
     <build>
         <plugins>
             <plugin>
@@ -29,6 +38,11 @@
                 <configuration>
                     <mainClass>ve.edu.unimet.so.project2.project2os.Project2OS</mainClass>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/ve/edu/unimet/so/project2/coordinator/channel/CoordinatorChannels.java
+++ b/src/main/java/ve/edu/unimet/so/project2/coordinator/channel/CoordinatorChannels.java
@@ -1,0 +1,137 @@
+package ve.edu.unimet.so.project2.coordinator.channel;
+
+import java.util.concurrent.Semaphore;
+import ve.edu.unimet.so.project2.coordinator.command.CoordinatorCommand;
+import ve.edu.unimet.so.project2.datastructures.LinkedQueue;
+
+public final class CoordinatorChannels {
+
+    private final LinkedQueue<CoordinatorCommand> incomingCommandQueue;
+    private final Semaphore commandQueueMutex;
+    private final Semaphore commandAvailable;
+    private final Semaphore diskChannelMutex;
+    private final Semaphore diskWorkAvailable;
+    private final Semaphore diskResultAvailable;
+
+    private DiskTask pendingDiskTask;
+    private DiskServiceResult completedDiskResult;
+
+    public CoordinatorChannels() {
+        this.incomingCommandQueue = new LinkedQueue<>();
+        this.commandQueueMutex = new Semaphore(1);
+        this.commandAvailable = new Semaphore(0);
+        this.diskChannelMutex = new Semaphore(1);
+        this.diskWorkAvailable = new Semaphore(0);
+        this.diskResultAvailable = new Semaphore(0);
+        this.pendingDiskTask = null;
+        this.completedDiskResult = null;
+    }
+
+    public void enqueueCommand(CoordinatorCommand command) {
+        if (command == null) {
+            throw new IllegalArgumentException("command cannot be null");
+        }
+        commandQueueMutex.acquireUninterruptibly();
+        try {
+            incomingCommandQueue.enqueue(command);
+        } finally {
+            commandQueueMutex.release();
+        }
+        commandAvailable.release();
+    }
+
+    public CoordinatorCommand pollCommand() {
+        if (!commandAvailable.tryAcquire()) {
+            return null;
+        }
+
+        commandQueueMutex.acquireUninterruptibly();
+        try {
+            return incomingCommandQueue.dequeue();
+        } finally {
+            commandQueueMutex.release();
+        }
+    }
+
+    public boolean isCommandQueueEmpty() {
+        commandQueueMutex.acquireUninterruptibly();
+        try {
+            return incomingCommandQueue.isEmpty();
+        } finally {
+            commandQueueMutex.release();
+        }
+    }
+
+    public void publishDiskTask(DiskTask task) {
+        if (task == null) {
+            throw new IllegalArgumentException("task cannot be null");
+        }
+        diskChannelMutex.acquireUninterruptibly();
+        try {
+            if (pendingDiskTask != null) {
+                throw new IllegalStateException("pendingDiskTask is already occupied");
+            }
+            pendingDiskTask = task;
+        } finally {
+            diskChannelMutex.release();
+        }
+        diskWorkAvailable.release();
+    }
+
+    public DiskTask awaitNextDiskTask() {
+        diskWorkAvailable.acquireUninterruptibly();
+        diskChannelMutex.acquireUninterruptibly();
+        try {
+            DiskTask task = pendingDiskTask;
+            pendingDiskTask = null;
+            return task;
+        } finally {
+            diskChannelMutex.release();
+        }
+    }
+
+    public void publishCompletedDiskResult(DiskServiceResult result) {
+        if (result == null) {
+            throw new IllegalArgumentException("result cannot be null");
+        }
+        diskChannelMutex.acquireUninterruptibly();
+        try {
+            if (completedDiskResult != null) {
+                throw new IllegalStateException("completedDiskResult is already occupied");
+            }
+            completedDiskResult = result;
+        } finally {
+            diskChannelMutex.release();
+        }
+        diskResultAvailable.release();
+    }
+
+    public DiskServiceResult pollCompletedDiskResult() {
+        if (!diskResultAvailable.tryAcquire()) {
+            return null;
+        }
+
+        diskChannelMutex.acquireUninterruptibly();
+        try {
+            DiskServiceResult result = completedDiskResult;
+            completedDiskResult = null;
+            return result;
+        } finally {
+            diskChannelMutex.release();
+        }
+    }
+
+    public boolean hasPendingDiskItems() {
+        diskChannelMutex.acquireUninterruptibly();
+        try {
+            return pendingDiskTask != null || completedDiskResult != null;
+        } finally {
+            diskChannelMutex.release();
+        }
+    }
+
+    public void releaseForShutdown() {
+        commandAvailable.release();
+        diskWorkAvailable.release();
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/coordinator/channel/DiskServiceResult.java
+++ b/src/main/java/ve/edu/unimet/so/project2/coordinator/channel/DiskServiceResult.java
@@ -1,0 +1,66 @@
+package ve.edu.unimet.so.project2.coordinator.channel;
+
+public final class DiskServiceResult {
+
+    private final String processId;
+    private final String requestId;
+    private final int previousHeadBlock;
+    private final int newHeadBlock;
+    private final int traveledDistance;
+    private final String serviceThreadName;
+
+    public DiskServiceResult(
+            String processId,
+            String requestId,
+            int previousHeadBlock,
+            int newHeadBlock,
+            int traveledDistance,
+            String serviceThreadName) {
+        this.processId = requireNonBlank(processId, "processId");
+        this.requestId = requireNonBlank(requestId, "requestId");
+        if (previousHeadBlock < 0) {
+            throw new IllegalArgumentException("previousHeadBlock cannot be negative");
+        }
+        if (newHeadBlock < 0) {
+            throw new IllegalArgumentException("newHeadBlock cannot be negative");
+        }
+        if (traveledDistance < 0) {
+            throw new IllegalArgumentException("traveledDistance cannot be negative");
+        }
+        this.previousHeadBlock = previousHeadBlock;
+        this.newHeadBlock = newHeadBlock;
+        this.traveledDistance = traveledDistance;
+        this.serviceThreadName = requireNonBlank(serviceThreadName, "serviceThreadName");
+    }
+
+    public String getProcessId() {
+        return processId;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public int getPreviousHeadBlock() {
+        return previousHeadBlock;
+    }
+
+    public int getNewHeadBlock() {
+        return newHeadBlock;
+    }
+
+    public int getTraveledDistance() {
+        return traveledDistance;
+    }
+
+    public String getServiceThreadName() {
+        return serviceThreadName;
+    }
+
+    private static String requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/coordinator/channel/DiskTask.java
+++ b/src/main/java/ve/edu/unimet/so/project2/coordinator/channel/DiskTask.java
@@ -1,0 +1,59 @@
+package ve.edu.unimet.so.project2.coordinator.channel;
+
+public final class DiskTask {
+
+    private final String processId;
+    private final String requestId;
+    private final int previousHeadBlock;
+    private final int newHeadBlock;
+    private final int traveledDistance;
+
+    public DiskTask(
+            String processId,
+            String requestId,
+            int previousHeadBlock,
+            int newHeadBlock,
+            int traveledDistance) {
+        this.processId = requireNonBlank(processId, "processId");
+        this.requestId = requireNonBlank(requestId, "requestId");
+        if (previousHeadBlock < 0) {
+            throw new IllegalArgumentException("previousHeadBlock cannot be negative");
+        }
+        if (newHeadBlock < 0) {
+            throw new IllegalArgumentException("newHeadBlock cannot be negative");
+        }
+        if (traveledDistance < 0) {
+            throw new IllegalArgumentException("traveledDistance cannot be negative");
+        }
+        this.previousHeadBlock = previousHeadBlock;
+        this.newHeadBlock = newHeadBlock;
+        this.traveledDistance = traveledDistance;
+    }
+
+    public String getProcessId() {
+        return processId;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public int getPreviousHeadBlock() {
+        return previousHeadBlock;
+    }
+
+    public int getNewHeadBlock() {
+        return newHeadBlock;
+    }
+
+    public int getTraveledDistance() {
+        return traveledDistance;
+    }
+
+    private static String requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/coordinator/command/CoordinatorCommand.java
+++ b/src/main/java/ve/edu/unimet/so/project2/coordinator/command/CoordinatorCommand.java
@@ -1,0 +1,5 @@
+package ve.edu.unimet.so.project2.coordinator.command;
+
+public interface CoordinatorCommand {
+    void execute();
+}

--- a/src/main/java/ve/edu/unimet/so/project2/coordinator/core/CoordinatorOperationHandler.java
+++ b/src/main/java/ve/edu/unimet/so/project2/coordinator/core/CoordinatorOperationHandler.java
@@ -1,0 +1,18 @@
+package ve.edu.unimet.so.project2.coordinator.core;
+
+import ve.edu.unimet.so.project2.coordinator.channel.DiskServiceResult;
+import ve.edu.unimet.so.project2.process.ProcessControlBlock;
+
+@FunctionalInterface
+public interface CoordinatorOperationHandler {
+
+    /**
+     * Applies the logical operation in the coordinator thread after disk service
+     * finishes. The handler must not perform scheduling, journal transitions or
+     * lock management.
+     */
+    OperationApplyResult apply(
+            PreparedOperationCommand command,
+            ProcessControlBlock process,
+            DiskServiceResult diskServiceResult);
+}

--- a/src/main/java/ve/edu/unimet/so/project2/coordinator/core/OperationApplyResult.java
+++ b/src/main/java/ve/edu/unimet/so/project2/coordinator/core/OperationApplyResult.java
@@ -1,0 +1,45 @@
+package ve.edu.unimet.so.project2.coordinator.core;
+
+import ve.edu.unimet.so.project2.process.ResultStatus;
+
+public final class OperationApplyResult {
+
+    private final ResultStatus resultStatus;
+    private final String errorMessage;
+
+    public OperationApplyResult(ResultStatus resultStatus, String errorMessage) {
+        if (resultStatus == null) {
+            throw new IllegalArgumentException("resultStatus cannot be null");
+        }
+        this.resultStatus = resultStatus;
+        this.errorMessage = normalizeOptional(errorMessage);
+    }
+
+    public static OperationApplyResult success() {
+        return new OperationApplyResult(ResultStatus.SUCCESS, null);
+    }
+
+    public static OperationApplyResult failed(String errorMessage) {
+        return new OperationApplyResult(ResultStatus.FAILED, errorMessage);
+    }
+
+    public static OperationApplyResult cancelled(String errorMessage) {
+        return new OperationApplyResult(ResultStatus.CANCELLED, errorMessage);
+    }
+
+    public ResultStatus getResultStatus() {
+        return resultStatus;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    private static String normalizeOptional(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/coordinator/core/PreparedJournalData.java
+++ b/src/main/java/ve/edu/unimet/so/project2/coordinator/core/PreparedJournalData.java
@@ -1,0 +1,49 @@
+package ve.edu.unimet.so.project2.coordinator.core;
+
+import ve.edu.unimet.so.project2.journal.undo.JournalUndoData;
+
+public final class PreparedJournalData {
+
+    private final JournalUndoData undoData;
+    private final String targetNodeId;
+    private final String ownerUserId;
+    private final String description;
+
+    public PreparedJournalData(
+            JournalUndoData undoData,
+            String targetNodeId,
+            String ownerUserId,
+            String description) {
+        if (undoData == null) {
+            throw new IllegalArgumentException("undoData cannot be null");
+        }
+        this.undoData = undoData;
+        this.targetNodeId = normalizeOptional(targetNodeId);
+        this.ownerUserId = normalizeOptional(ownerUserId);
+        this.description = normalizeOptional(description);
+    }
+
+    public JournalUndoData getUndoData() {
+        return undoData;
+    }
+
+    public String getTargetNodeId() {
+        return targetNodeId;
+    }
+
+    public String getOwnerUserId() {
+        return ownerUserId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    private static String normalizeOptional(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/coordinator/core/PreparedOperationCommand.java
+++ b/src/main/java/ve/edu/unimet/so/project2/coordinator/core/PreparedOperationCommand.java
@@ -1,0 +1,188 @@
+package ve.edu.unimet.so.project2.coordinator.core;
+
+import ve.edu.unimet.so.project2.filesystem.FsNodeType;
+import ve.edu.unimet.so.project2.journal.undo.CreateDirectoryUndoData;
+import ve.edu.unimet.so.project2.journal.undo.CreateFileUndoData;
+import ve.edu.unimet.so.project2.journal.undo.DeleteDirectoryUndoData;
+import ve.edu.unimet.so.project2.journal.undo.DeleteFileUndoData;
+import ve.edu.unimet.so.project2.journal.undo.JournalUndoData;
+import ve.edu.unimet.so.project2.journal.undo.UpdateRenameUndoData;
+import ve.edu.unimet.so.project2.locking.LockType;
+import ve.edu.unimet.so.project2.process.IoOperationType;
+
+public final class PreparedOperationCommand {
+
+    private final String requestId;
+    private final String processId;
+    private final String ownerUserId;
+    private final IoOperationType operationType;
+    private final FsNodeType targetNodeType;
+    private final String targetPath;
+    private final String targetNodeId;
+    private final int targetBlock;
+    private final int requestedSizeInBlocks;
+    private final LockType requiredLockType;
+    private final PreparedJournalData preparedJournalData;
+    private final CoordinatorOperationHandler operationHandler;
+
+    public PreparedOperationCommand(
+            String requestId,
+            String processId,
+            String ownerUserId,
+            IoOperationType operationType,
+            FsNodeType targetNodeType,
+            String targetPath,
+            String targetNodeId,
+            int targetBlock,
+            int requestedSizeInBlocks,
+            LockType requiredLockType,
+            PreparedJournalData preparedJournalData,
+            CoordinatorOperationHandler operationHandler) {
+        this.requestId = requireNonBlank(requestId, "requestId");
+        this.processId = requireNonBlank(processId, "processId");
+        this.ownerUserId = requireNonBlank(ownerUserId, "ownerUserId");
+        if (operationType == null) {
+            throw new IllegalArgumentException("operationType cannot be null");
+        }
+        if (targetNodeType == null) {
+            throw new IllegalArgumentException("targetNodeType cannot be null");
+        }
+        this.targetPath = requireNonBlank(targetPath, "targetPath");
+        this.targetNodeId = normalizeOptional(targetNodeId);
+        if (targetBlock < 0) {
+            throw new IllegalArgumentException("targetBlock cannot be negative");
+        }
+        if (requestedSizeInBlocks < 0) {
+            throw new IllegalArgumentException("requestedSizeInBlocks cannot be negative");
+        }
+        if (operationHandler == null) {
+            throw new IllegalArgumentException("operationHandler cannot be null");
+        }
+
+        this.operationType = operationType;
+        this.targetNodeType = targetNodeType;
+        this.targetBlock = targetBlock;
+        this.requestedSizeInBlocks = requestedSizeInBlocks;
+        this.requiredLockType = requiredLockType;
+        this.preparedJournalData = preparedJournalData;
+        this.operationHandler = operationHandler;
+
+        validateTargetBinding(operationType, this.targetNodeId);
+        validateJournalRequirement(operationType, preparedJournalData);
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public String getProcessId() {
+        return processId;
+    }
+
+    public String getOwnerUserId() {
+        return ownerUserId;
+    }
+
+    public IoOperationType getOperationType() {
+        return operationType;
+    }
+
+    public FsNodeType getTargetNodeType() {
+        return targetNodeType;
+    }
+
+    public String getTargetPath() {
+        return targetPath;
+    }
+
+    public String getTargetNodeId() {
+        return targetNodeId;
+    }
+
+    public int getTargetBlock() {
+        return targetBlock;
+    }
+
+    public int getRequestedSizeInBlocks() {
+        return requestedSizeInBlocks;
+    }
+
+    public LockType getRequiredLockType() {
+        return requiredLockType;
+    }
+
+    public PreparedJournalData getPreparedJournalData() {
+        return preparedJournalData;
+    }
+
+    public CoordinatorOperationHandler getOperationHandler() {
+        return operationHandler;
+    }
+
+    public boolean requiresJournal() {
+        return operationType != IoOperationType.READ;
+    }
+
+    private static void validateTargetBinding(IoOperationType operationType, String targetNodeId) {
+        if (operationType == IoOperationType.CREATE) {
+            return;
+        }
+        if (targetNodeId == null) {
+            throw new IllegalArgumentException("non-CREATE operations must include targetNodeId");
+        }
+    }
+
+    private static void validateJournalRequirement(
+            IoOperationType operationType,
+            PreparedJournalData preparedJournalData) {
+        if (operationType == IoOperationType.READ) {
+            if (preparedJournalData != null) {
+                throw new IllegalArgumentException("READ operations must not include journal data");
+            }
+            return;
+        }
+        if (preparedJournalData == null) {
+            throw new IllegalArgumentException("modifying operations require preparedJournalData");
+        }
+        validateUndoDataCompatibility(operationType, preparedJournalData.getUndoData());
+    }
+
+    private static void validateUndoDataCompatibility(
+            IoOperationType operationType,
+            JournalUndoData undoData) {
+        switch (operationType) {
+            case CREATE -> {
+                if (!(undoData instanceof CreateFileUndoData) && !(undoData instanceof CreateDirectoryUndoData)) {
+                    throw new IllegalArgumentException("CREATE operations require create undo data");
+                }
+            }
+            case DELETE -> {
+                if (!(undoData instanceof DeleteFileUndoData) && !(undoData instanceof DeleteDirectoryUndoData)) {
+                    throw new IllegalArgumentException("DELETE operations require delete undo data");
+                }
+            }
+            case UPDATE -> {
+                if (!(undoData instanceof UpdateRenameUndoData)) {
+                    throw new IllegalArgumentException("UPDATE operations require rename undo data");
+                }
+            }
+            case READ -> throw new IllegalArgumentException("READ operations must not include journal data");
+            default -> throw new IllegalArgumentException("unsupported operationType: " + operationType);
+        }
+    }
+
+    private static String requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
+        }
+        return value;
+    }
+
+    private static String normalizeOptional(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/coordinator/core/SimulationCoordinator.java
+++ b/src/main/java/ve/edu/unimet/so/project2/coordinator/core/SimulationCoordinator.java
@@ -1,0 +1,587 @@
+package ve.edu.unimet.so.project2.coordinator.core;
+
+import ve.edu.unimet.so.project2.coordinator.channel.CoordinatorChannels;
+import ve.edu.unimet.so.project2.coordinator.channel.DiskServiceResult;
+import ve.edu.unimet.so.project2.coordinator.channel.DiskTask;
+import ve.edu.unimet.so.project2.coordinator.command.CoordinatorCommand;
+import ve.edu.unimet.so.project2.coordinator.snapshot.SimulationSnapshot;
+import ve.edu.unimet.so.project2.coordinator.snapshot.SimulationSnapshotFactory;
+import ve.edu.unimet.so.project2.coordinator.state.CoordinatorProcessStore;
+import ve.edu.unimet.so.project2.coordinator.state.ProcessExecutionContext;
+import ve.edu.unimet.so.project2.disk.DiskHead;
+import ve.edu.unimet.so.project2.disk.DiskHeadDirection;
+import ve.edu.unimet.so.project2.disk.SimulatedDisk;
+import ve.edu.unimet.so.project2.journal.JournalEntry;
+import ve.edu.unimet.so.project2.journal.JournalManager;
+import ve.edu.unimet.so.project2.locking.LockAcquireResult;
+import ve.edu.unimet.so.project2.locking.LockReleaseResult;
+import ve.edu.unimet.so.project2.locking.LockWaitEntry;
+import ve.edu.unimet.so.project2.locking.LockTable;
+import ve.edu.unimet.so.project2.process.IoRequest;
+import ve.edu.unimet.so.project2.process.ProcessControlBlock;
+import ve.edu.unimet.so.project2.process.ResultStatus;
+import ve.edu.unimet.so.project2.process.WaitReason;
+import ve.edu.unimet.so.project2.scheduler.DiskScheduleDecision;
+import ve.edu.unimet.so.project2.scheduler.DiskScheduler;
+import ve.edu.unimet.so.project2.scheduler.DiskSchedulingPolicy;
+
+public final class SimulationCoordinator {
+
+    private final SimulatedDisk disk;
+    private final LockTable lockTable;
+    private final JournalManager journalManager;
+    private final DiskScheduler diskScheduler;
+    private final CoordinatorChannels channels;
+    private final CoordinatorProcessStore processStore;
+    private final SimulationSnapshotFactory snapshotFactory;
+
+    private volatile SimulationSnapshot latestSnapshot;
+
+    private DiskSchedulingPolicy activePolicy;
+    private long nextArrivalOrder;
+    private long nextTick;
+    private int totalSeekDistance;
+    private int activeDiskTasks;
+    private int maxConcurrentDiskTasksObserved;
+
+    private volatile boolean shutdownRequested;
+    private volatile boolean started;
+    private volatile boolean acceptingCommands;
+    private Thread coordinatorThread;
+    private Thread diskThread;
+
+    public SimulationCoordinator(
+            SimulatedDisk disk,
+            LockTable lockTable,
+            JournalManager journalManager,
+            DiskSchedulingPolicy initialPolicy) {
+        if (disk == null) {
+            throw new IllegalArgumentException("disk cannot be null");
+        }
+        if (lockTable == null) {
+            throw new IllegalArgumentException("lockTable cannot be null");
+        }
+        if (journalManager == null) {
+            throw new IllegalArgumentException("journalManager cannot be null");
+        }
+        if (initialPolicy == null) {
+            throw new IllegalArgumentException("initialPolicy cannot be null");
+        }
+        this.disk = disk;
+        this.lockTable = lockTable;
+        this.journalManager = journalManager;
+        this.diskScheduler = new DiskScheduler();
+        this.channels = new CoordinatorChannels();
+        this.processStore = new CoordinatorProcessStore();
+        this.snapshotFactory = new SimulationSnapshotFactory();
+        this.activePolicy = initialPolicy;
+        this.nextArrivalOrder = 0L;
+        this.nextTick = 0L;
+        this.totalSeekDistance = 0;
+        this.activeDiskTasks = 0;
+        this.maxConcurrentDiskTasksObserved = 0;
+        this.shutdownRequested = false;
+        this.started = false;
+        this.acceptingCommands = false;
+        publishSnapshot();
+    }
+
+    public synchronized void start() {
+        if (started) {
+            return;
+        }
+
+        shutdownRequested = false;
+        acceptingCommands = true;
+        coordinatorThread = new Thread(this::runCoordinatorLoop, "SimulationCoordinatorThread");
+        diskThread = new Thread(this::runDiskLoop, "DiskExecutionThread");
+        started = true;
+        coordinatorThread.start();
+        diskThread.start();
+    }
+
+    public synchronized void shutdown() {
+        if (!started) {
+            return;
+        }
+
+        acceptingCommands = false;
+        shutdownRequested = true;
+        channels.releaseForShutdown();
+
+        joinQuietly(coordinatorThread);
+        joinQuietly(diskThread);
+
+        coordinatorThread = null;
+        diskThread = null;
+        started = false;
+        publishSnapshot();
+    }
+
+    public void submitOperation(PreparedOperationCommand command) {
+        if (command == null) {
+            throw new IllegalArgumentException("command cannot be null");
+        }
+        requireStartedAndAcceptingCommands();
+        channels.enqueueCommand(new SubmitOperationCoordinatorCommand(command));
+    }
+
+    public void changePolicy(DiskSchedulingPolicy policy) {
+        if (policy == null) {
+            throw new IllegalArgumentException("policy cannot be null");
+        }
+        requireStartedAndAcceptingCommands();
+        channels.enqueueCommand(new ChangePolicyCoordinatorCommand(policy));
+    }
+
+    public void changeHeadDirection(DiskHeadDirection direction) {
+        if (direction == null) {
+            throw new IllegalArgumentException("direction cannot be null");
+        }
+        requireStartedAndAcceptingCommands();
+        channels.enqueueCommand(new ChangeDirectionCoordinatorCommand(direction));
+    }
+
+    public SimulationSnapshot getLatestSnapshot() {
+        return latestSnapshot;
+    }
+
+    private void runCoordinatorLoop() {
+        while (true) {
+            boolean worked = false;
+
+            DiskServiceResult diskResult = channels.pollCompletedDiskResult();
+            if (diskResult != null) {
+                finishRunningProcess(diskResult);
+                worked = true;
+            }
+
+            CoordinatorCommand command = channels.pollCommand();
+            if (command != null) {
+                executeCommandSafely(command);
+                worked = true;
+            }
+
+            if (reconcileBlockedLockWaiters()) {
+                worked = true;
+            }
+
+            if (processStore.getRunningProcess() == null && tryDispatchNextReady()) {
+                worked = true;
+            }
+
+            publishSnapshot();
+
+            if (shutdownRequested
+                    && processStore.getRunningProcess() == null
+                    && channels.isCommandQueueEmpty()
+                    && !channels.hasPendingDiskItems()) {
+                break;
+            }
+
+            if (!worked) {
+                sleepQuietly(2L);
+            }
+        }
+
+        publishSnapshot();
+    }
+
+    private void runDiskLoop() {
+        while (true) {
+            DiskTask task = channels.awaitNextDiskTask();
+            if (task == null) {
+                if (shutdownRequested) {
+                    break;
+                }
+                continue;
+            }
+
+            channels.publishCompletedDiskResult(new DiskServiceResult(
+                    task.getProcessId(),
+                    task.getRequestId(),
+                    task.getPreviousHeadBlock(),
+                    task.getNewHeadBlock(),
+                    task.getTraveledDistance(),
+                    Thread.currentThread().getName()));
+        }
+    }
+
+    private boolean tryDispatchNextReady() {
+        ProcessControlBlock[] readySnapshot = processStore.getReadySnapshot();
+        if (readySnapshot.length == 0) {
+            return false;
+        }
+
+        DiskHead headSnapshot = disk.getHead();
+        DiskScheduleDecision decision = diskScheduler.selectNext(
+                activePolicy,
+                headSnapshot,
+                readySnapshot,
+                disk.getTotalBlocks());
+        if (decision == null) {
+            return false;
+        }
+
+        ProcessControlBlock selected = processStore.removeReadyProcessById(decision.getSelectedProcessId());
+        if (selected == null) {
+            return false;
+        }
+
+        if (!tryAcquireRequiredLock(selected)) {
+            return true;
+        }
+
+        selected.markRunning(nextTick++);
+        processStore.setRunningProcess(selected);
+
+        ProcessExecutionContext context = processStore.requireContext(selected.getProcessId());
+        registerPendingJournalIfNeeded(context);
+        applyDispatchDecision(selected, decision);
+        channels.publishDiskTask(new DiskTask(
+                selected.getProcessId(),
+                selected.getRequest().getRequestId(),
+                decision.getPreviousHeadBlock(),
+                decision.getNewHeadBlock(),
+                decision.getTraveledDistance()));
+        recordActiveDiskTask();
+        return true;
+    }
+
+    private void registerPendingJournalIfNeeded(ProcessExecutionContext context) {
+        PreparedOperationCommand command = context.getCommand();
+        if (!command.requiresJournal()) {
+            return;
+        }
+
+        JournalEntry journalEntry = journalManager.registerPending(
+                command.getOperationType(),
+                command.getTargetPath(),
+                command.getPreparedJournalData().getUndoData(),
+                command.getPreparedJournalData().getTargetNodeId(),
+                command.getPreparedJournalData().getOwnerUserId(),
+                command.getPreparedJournalData().getDescription());
+        context.setTransactionId(journalEntry.getTransactionId());
+    }
+
+    private void applyDispatchDecision(ProcessControlBlock selected, DiskScheduleDecision decision) {
+        disk.moveHeadTo(decision.getNewHeadBlock());
+        disk.setHeadDirection(decision.getResultingDirection());
+        totalSeekDistance += decision.getTraveledDistance();
+        processStore.registerDispatch(new SimulationSnapshot.DispatchRecord(
+                selected.getProcessId(),
+                selected.getRequest().getRequestId(),
+                decision.getPreviousHeadBlock(),
+                decision.getNewHeadBlock(),
+                decision.getTraveledDistance(),
+                decision.getResultingDirection()));
+    }
+
+    private void recordActiveDiskTask() {
+        activeDiskTasks++;
+        if (activeDiskTasks > maxConcurrentDiskTasksObserved) {
+            maxConcurrentDiskTasksObserved = activeDiskTasks;
+        }
+    }
+
+    private void handleSubmitOperation(PreparedOperationCommand command) {
+        validateUniqueProcessId(command);
+        validateTargetBlockInRange(command);
+        long arrivalOrder = nextArrivalOrder++;
+        IoRequest request = new IoRequest(
+                command.getRequestId(),
+                command.getProcessId(),
+                command.getOperationType(),
+                command.getTargetNodeType(),
+                command.getTargetPath(),
+                command.getTargetNodeId(),
+                command.getTargetBlock(),
+                command.getRequestedSizeInBlocks(),
+                command.getOwnerUserId(),
+                arrivalOrder);
+        ProcessControlBlock process = new ProcessControlBlock(
+                command.getProcessId(),
+                command.getOwnerUserId(),
+                request,
+                command.getTargetNodeType(),
+                command.getTargetNodeId(),
+                command.getTargetPath(),
+                command.getTargetBlock(),
+                command.getRequiredLockType(),
+                nextTick++);
+        processStore.registerSubmittedProcess(process, command);
+        admitNextNewProcess();
+    }
+
+    private void admitNextNewProcess() {
+        ProcessControlBlock process = processStore.admitNextNewProcess();
+        if (process == null) {
+            return;
+        }
+        process.markReady(nextTick++);
+        processStore.addReadyProcess(process);
+    }
+
+    private boolean tryAcquireRequiredLock(ProcessControlBlock process) {
+        if (!requiresFileLock(process)) {
+            return true;
+        }
+
+        processStore.trackLockFileId(process.getTargetNodeId());
+        LockAcquireResult acquireResult = lockTable.tryAcquire(
+                process.getTargetNodeId(),
+                process.getProcessId(),
+                process.getRequiredLockType());
+        reactivateAwakenedProcesses(acquireResult);
+
+        if (acquireResult.isBlocked()) {
+            process.markBlocked(WaitReason.WAITING_LOCK, acquireResult.getBlockingProcessId());
+            processStore.addBlockedProcess(process);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void finishRunningProcess(DiskServiceResult diskResult) {
+        ProcessControlBlock runningProcess = processStore.getRunningProcess();
+        if (runningProcess == null) {
+            throw new IllegalStateException("received disk result without a running process");
+        }
+        if (!runningProcess.getProcessId().equals(diskResult.getProcessId())) {
+            throw new IllegalStateException("disk result process mismatch");
+        }
+
+        ProcessExecutionContext context = processStore.requireContext(runningProcess.getProcessId());
+        OperationApplyResult applyResult = invokeHandler(context.getCommand(), runningProcess, diskResult);
+        completeJournalTransition(context, applyResult);
+        releaseProcessLock(runningProcess);
+
+        runningProcess.markTerminated(applyResult.getResultStatus(), nextTick++, applyResult.getErrorMessage());
+        processStore.addTerminatedProcess(runningProcess);
+        processStore.clearRunningProcess();
+        activeDiskTasks = Math.max(0, activeDiskTasks - 1);
+    }
+
+    private OperationApplyResult invokeHandler(
+            PreparedOperationCommand command,
+            ProcessControlBlock process,
+            DiskServiceResult diskResult) {
+        try {
+            OperationApplyResult result = command.getOperationHandler().apply(command, process, diskResult);
+            if (result == null) {
+                return OperationApplyResult.failed("operation handler returned null");
+            }
+            return result;
+        } catch (RuntimeException exception) {
+            return OperationApplyResult.failed(exception.getMessage() == null
+                    ? exception.getClass().getSimpleName()
+                    : exception.getMessage());
+        }
+    }
+
+    private void completeJournalTransition(ProcessExecutionContext context, OperationApplyResult applyResult) {
+        if (!context.getCommand().requiresJournal()) {
+            return;
+        }
+        if (context.getTransactionId() == null) {
+            throw new IllegalStateException("missing transactionId for modifying operation");
+        }
+
+        if (applyResult.getResultStatus() == ResultStatus.SUCCESS) {
+            journalManager.markCommitted(context.getTransactionId());
+        }
+    }
+
+    private void releaseProcessLock(ProcessControlBlock process) {
+        if (!requiresFileLock(process)) {
+            return;
+        }
+
+        LockReleaseResult releaseResult = lockTable.releaseByProcess(process.getTargetNodeId(), process.getProcessId());
+        reactivateAwakenedProcesses(releaseResult);
+    }
+
+    private void reactivateAwakenedProcesses(LockAcquireResult acquireResult) {
+        for (int i = 0; i < acquireResult.getAwakenedCount(); i++) {
+            reactivateBlockedProcess(acquireResult.getAwakenedEntryAt(i));
+        }
+    }
+
+    private void reactivateAwakenedProcesses(LockReleaseResult releaseResult) {
+        for (int i = 0; i < releaseResult.getAwakenedCount(); i++) {
+            reactivateBlockedProcess(releaseResult.getAwakenedEntryAt(i));
+        }
+    }
+
+    private void reactivateBlockedProcess(LockWaitEntry awakenedEntry) {
+        ProcessControlBlock process = processStore.removeBlockedProcessById(awakenedEntry.getProcessId());
+        if (process == null) {
+            return;
+        }
+        process.markReady(nextTick++);
+        processStore.addReadyProcess(process);
+    }
+
+    private boolean reconcileBlockedLockWaiters() {
+        ProcessControlBlock[] blockedSnapshot = processStore.getBlockedSnapshot();
+        boolean changed = false;
+
+        for (ProcessControlBlock process : blockedSnapshot) {
+            if (process.getWaitReason() != WaitReason.WAITING_LOCK || !requiresFileLock(process)) {
+                continue;
+            }
+
+            LockAcquireResult acquireResult = lockTable.tryAcquire(
+                    process.getTargetNodeId(),
+                    process.getProcessId(),
+                    process.getRequiredLockType());
+            reactivateAwakenedProcesses(acquireResult);
+
+            if (acquireResult.isBlocked()) {
+                String previousBlockingProcessId = process.getBlockedByProcessId();
+                process.markBlocked(WaitReason.WAITING_LOCK, acquireResult.getBlockingProcessId());
+                if (!sameOptionalValue(previousBlockingProcessId, process.getBlockedByProcessId())) {
+                    changed = true;
+                }
+                continue;
+            }
+
+            if (acquireResult.isGranted() || acquireResult.isAlreadyHeld()) {
+                ProcessControlBlock reactivated = processStore.removeBlockedProcessById(process.getProcessId());
+                if (reactivated == null) {
+                    continue;
+                }
+                reactivated.markReady(nextTick++);
+                processStore.addReadyProcess(reactivated);
+                changed = true;
+            }
+        }
+
+        return changed;
+    }
+
+    private void publishSnapshot() {
+        latestSnapshot = snapshotFactory.build(
+                activePolicy,
+                disk,
+                processStore,
+                lockTable,
+                journalManager,
+                totalSeekDistance,
+                maxConcurrentDiskTasksObserved);
+    }
+
+    private void executeCommandSafely(CoordinatorCommand command) {
+        try {
+            command.execute();
+        } catch (RuntimeException exception) {
+            if (command instanceof SubmitOperationCoordinatorCommand submitCommand) {
+                processStore.addRejectedTerminatedProcess(submitCommand.command, exception.getMessage());
+            }
+        }
+    }
+
+    private void validateTargetBlockInRange(PreparedOperationCommand command) {
+        if (!disk.isValidIndex(command.getTargetBlock())) {
+            throw new IllegalArgumentException("targetBlock is out of disk range: " + command.getTargetBlock());
+        }
+    }
+
+    private void validateUniqueProcessId(PreparedOperationCommand command) {
+        if (processStore.containsProcessId(command.getProcessId())) {
+            throw new IllegalArgumentException("duplicate processId is not allowed: " + command.getProcessId());
+        }
+    }
+
+    private boolean requiresFileLock(ProcessControlBlock process) {
+        return process.getRequiredLockType() != null && process.getTargetNodeId() != null;
+    }
+
+    private void requireStartedAndAcceptingCommands() {
+        if (!started) {
+            throw new IllegalStateException("SimulationCoordinator must be started before enqueuing commands");
+        }
+        if (!acceptingCommands) {
+            throw new IllegalStateException("SimulationCoordinator is not accepting commands");
+        }
+    }
+
+    private void joinQuietly(Thread thread) {
+        if (thread == null) {
+            return;
+        }
+        boolean interrupted = false;
+        try {
+            while (true) {
+                try {
+                    thread.join();
+                    break;
+                } catch (InterruptedException ignored) {
+                    interrupted = true;
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private boolean sameOptionalValue(String left, String right) {
+        if (left == null) {
+            return right == null;
+        }
+        return left.equals(right);
+    }
+
+    private final class SubmitOperationCoordinatorCommand implements CoordinatorCommand {
+
+        private final PreparedOperationCommand command;
+
+        private SubmitOperationCoordinatorCommand(PreparedOperationCommand command) {
+            this.command = command;
+        }
+
+        @Override
+        public void execute() {
+            handleSubmitOperation(command);
+        }
+    }
+
+    private final class ChangePolicyCoordinatorCommand implements CoordinatorCommand {
+
+        private final DiskSchedulingPolicy policy;
+
+        private ChangePolicyCoordinatorCommand(DiskSchedulingPolicy policy) {
+            this.policy = policy;
+        }
+
+        @Override
+        public void execute() {
+            activePolicy = policy;
+        }
+    }
+
+    private final class ChangeDirectionCoordinatorCommand implements CoordinatorCommand {
+
+        private final DiskHeadDirection direction;
+
+        private ChangeDirectionCoordinatorCommand(DiskHeadDirection direction) {
+            this.direction = direction;
+        }
+
+        @Override
+        public void execute() {
+            disk.setHeadDirection(direction);
+        }
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/coordinator/snapshot/SimulationSnapshot.java
+++ b/src/main/java/ve/edu/unimet/so/project2/coordinator/snapshot/SimulationSnapshot.java
@@ -1,0 +1,382 @@
+package ve.edu.unimet.so.project2.coordinator.snapshot;
+
+import ve.edu.unimet.so.project2.disk.DiskHeadDirection;
+import ve.edu.unimet.so.project2.journal.JournalStatus;
+import ve.edu.unimet.so.project2.process.IoOperationType;
+import ve.edu.unimet.so.project2.process.ProcessState;
+import ve.edu.unimet.so.project2.process.ResultStatus;
+import ve.edu.unimet.so.project2.process.WaitReason;
+import ve.edu.unimet.so.project2.scheduler.DiskSchedulingPolicy;
+
+public final class SimulationSnapshot {
+
+    private final DiskSchedulingPolicy policy;
+    private final int headBlock;
+    private final DiskHeadDirection headDirection;
+    private final int totalSeekDistance;
+    private final int maxConcurrentDiskTasksObserved;
+    private final String runningProcessId;
+    private final ProcessSnapshot[] newProcesses;
+    private final ProcessSnapshot[] readyProcesses;
+    private final ProcessSnapshot[] blockedProcesses;
+    private final ProcessSnapshot[] terminatedProcesses;
+    private final LockSummary[] locks;
+    private final JournalEntrySummary[] journalEntries;
+    private final DispatchRecord[] dispatchHistory;
+
+    public SimulationSnapshot(
+            DiskSchedulingPolicy policy,
+            int headBlock,
+            DiskHeadDirection headDirection,
+            int totalSeekDistance,
+            int maxConcurrentDiskTasksObserved,
+            String runningProcessId,
+            ProcessSnapshot[] newProcesses,
+            ProcessSnapshot[] readyProcesses,
+            ProcessSnapshot[] blockedProcesses,
+            ProcessSnapshot[] terminatedProcesses,
+            LockSummary[] locks,
+            JournalEntrySummary[] journalEntries,
+            DispatchRecord[] dispatchHistory) {
+        if (policy == null) {
+            throw new IllegalArgumentException("policy cannot be null");
+        }
+        if (headBlock < 0) {
+            throw new IllegalArgumentException("headBlock cannot be negative");
+        }
+        if (headDirection == null) {
+            throw new IllegalArgumentException("headDirection cannot be null");
+        }
+        if (totalSeekDistance < 0) {
+            throw new IllegalArgumentException("totalSeekDistance cannot be negative");
+        }
+        if (maxConcurrentDiskTasksObserved < 0) {
+            throw new IllegalArgumentException("maxConcurrentDiskTasksObserved cannot be negative");
+        }
+        this.policy = policy;
+        this.headBlock = headBlock;
+        this.headDirection = headDirection;
+        this.totalSeekDistance = totalSeekDistance;
+        this.maxConcurrentDiskTasksObserved = maxConcurrentDiskTasksObserved;
+        this.runningProcessId = normalizeOptional(runningProcessId);
+        this.newProcesses = copyProcessSnapshots(newProcesses);
+        this.readyProcesses = copyProcessSnapshots(readyProcesses);
+        this.blockedProcesses = copyProcessSnapshots(blockedProcesses);
+        this.terminatedProcesses = copyProcessSnapshots(terminatedProcesses);
+        this.locks = copyLockSummaries(locks);
+        this.journalEntries = copyJournalEntries(journalEntries);
+        this.dispatchHistory = copyDispatchRecords(dispatchHistory);
+    }
+
+    public DiskSchedulingPolicy getPolicy() {
+        return policy;
+    }
+
+    public int getHeadBlock() {
+        return headBlock;
+    }
+
+    public DiskHeadDirection getHeadDirection() {
+        return headDirection;
+    }
+
+    public int getTotalSeekDistance() {
+        return totalSeekDistance;
+    }
+
+    public int getMaxConcurrentDiskTasksObserved() {
+        return maxConcurrentDiskTasksObserved;
+    }
+
+    public String getRunningProcessId() {
+        return runningProcessId;
+    }
+
+    public ProcessSnapshot[] getNewProcessesSnapshot() {
+        return copyProcessSnapshots(newProcesses);
+    }
+
+    public ProcessSnapshot[] getReadyProcessesSnapshot() {
+        return copyProcessSnapshots(readyProcesses);
+    }
+
+    public ProcessSnapshot[] getBlockedProcessesSnapshot() {
+        return copyProcessSnapshots(blockedProcesses);
+    }
+
+    public ProcessSnapshot[] getTerminatedProcessesSnapshot() {
+        return copyProcessSnapshots(terminatedProcesses);
+    }
+
+    public LockSummary[] getLocksSnapshot() {
+        return copyLockSummaries(locks);
+    }
+
+    public JournalEntrySummary[] getJournalEntriesSnapshot() {
+        return copyJournalEntries(journalEntries);
+    }
+
+    public DispatchRecord[] getDispatchHistorySnapshot() {
+        return copyDispatchRecords(dispatchHistory);
+    }
+
+    private static ProcessSnapshot[] copyProcessSnapshots(ProcessSnapshot[] source) {
+        if (source == null) {
+            return new ProcessSnapshot[0];
+        }
+        ProcessSnapshot[] copy = new ProcessSnapshot[source.length];
+        System.arraycopy(source, 0, copy, 0, source.length);
+        return copy;
+    }
+
+    private static LockSummary[] copyLockSummaries(LockSummary[] source) {
+        if (source == null) {
+            return new LockSummary[0];
+        }
+        LockSummary[] copy = new LockSummary[source.length];
+        System.arraycopy(source, 0, copy, 0, source.length);
+        return copy;
+    }
+
+    private static JournalEntrySummary[] copyJournalEntries(JournalEntrySummary[] source) {
+        if (source == null) {
+            return new JournalEntrySummary[0];
+        }
+        JournalEntrySummary[] copy = new JournalEntrySummary[source.length];
+        System.arraycopy(source, 0, copy, 0, source.length);
+        return copy;
+    }
+
+    private static DispatchRecord[] copyDispatchRecords(DispatchRecord[] source) {
+        if (source == null) {
+            return new DispatchRecord[0];
+        }
+        DispatchRecord[] copy = new DispatchRecord[source.length];
+        System.arraycopy(source, 0, copy, 0, source.length);
+        return copy;
+    }
+
+    private static String normalizeOptional(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    public static final class ProcessSnapshot {
+
+        private final String processId;
+        private final String requestId;
+        private final ProcessState state;
+        private final WaitReason waitReason;
+        private final ResultStatus resultStatus;
+        private final String targetPath;
+        private final int targetBlock;
+        private final String blockedByProcessId;
+        private final String errorMessage;
+
+        public ProcessSnapshot(
+                String processId,
+                String requestId,
+                ProcessState state,
+                WaitReason waitReason,
+                ResultStatus resultStatus,
+                String targetPath,
+                int targetBlock,
+                String blockedByProcessId,
+                String errorMessage) {
+            this.processId = requireNonBlank(processId, "processId");
+            this.requestId = requireNonBlank(requestId, "requestId");
+            if (state == null) {
+                throw new IllegalArgumentException("state cannot be null");
+            }
+            if (waitReason == null) {
+                throw new IllegalArgumentException("waitReason cannot be null");
+            }
+            this.state = state;
+            this.waitReason = waitReason;
+            this.resultStatus = resultStatus;
+            this.targetPath = requireNonBlank(targetPath, "targetPath");
+            if (targetBlock < 0) {
+                throw new IllegalArgumentException("targetBlock cannot be negative");
+            }
+            this.targetBlock = targetBlock;
+            this.blockedByProcessId = normalizeOptional(blockedByProcessId);
+            this.errorMessage = normalizeOptional(errorMessage);
+        }
+
+        public String getProcessId() {
+            return processId;
+        }
+
+        public String getRequestId() {
+            return requestId;
+        }
+
+        public ProcessState getState() {
+            return state;
+        }
+
+        public WaitReason getWaitReason() {
+            return waitReason;
+        }
+
+        public ResultStatus getResultStatus() {
+            return resultStatus;
+        }
+
+        public String getTargetPath() {
+            return targetPath;
+        }
+
+        public int getTargetBlock() {
+            return targetBlock;
+        }
+
+        public String getBlockedByProcessId() {
+            return blockedByProcessId;
+        }
+
+        public String getErrorMessage() {
+            return errorMessage;
+        }
+    }
+
+    public static final class LockSummary {
+
+        private final String fileId;
+        private final int activeLockCount;
+        private final int waitingCount;
+        private final int pendingGrantCount;
+
+        public LockSummary(String fileId, int activeLockCount, int waitingCount, int pendingGrantCount) {
+            this.fileId = requireNonBlank(fileId, "fileId");
+            if (activeLockCount < 0 || waitingCount < 0 || pendingGrantCount < 0) {
+                throw new IllegalArgumentException("lock counters cannot be negative");
+            }
+            this.activeLockCount = activeLockCount;
+            this.waitingCount = waitingCount;
+            this.pendingGrantCount = pendingGrantCount;
+        }
+
+        public String getFileId() {
+            return fileId;
+        }
+
+        public int getActiveLockCount() {
+            return activeLockCount;
+        }
+
+        public int getWaitingCount() {
+            return waitingCount;
+        }
+
+        public int getPendingGrantCount() {
+            return pendingGrantCount;
+        }
+    }
+
+    public static final class JournalEntrySummary {
+
+        private final String transactionId;
+        private final IoOperationType operationType;
+        private final String targetPath;
+        private final JournalStatus status;
+
+        public JournalEntrySummary(
+                String transactionId,
+                IoOperationType operationType,
+                String targetPath,
+                JournalStatus status) {
+            this.transactionId = requireNonBlank(transactionId, "transactionId");
+            if (operationType == null) {
+                throw new IllegalArgumentException("operationType cannot be null");
+            }
+            this.targetPath = requireNonBlank(targetPath, "targetPath");
+            if (status == null) {
+                throw new IllegalArgumentException("status cannot be null");
+            }
+            this.operationType = operationType;
+            this.status = status;
+        }
+
+        public String getTransactionId() {
+            return transactionId;
+        }
+
+        public IoOperationType getOperationType() {
+            return operationType;
+        }
+
+        public String getTargetPath() {
+            return targetPath;
+        }
+
+        public JournalStatus getStatus() {
+            return status;
+        }
+    }
+
+    public static final class DispatchRecord {
+
+        private final String processId;
+        private final String requestId;
+        private final int previousHeadBlock;
+        private final int newHeadBlock;
+        private final int traveledDistance;
+        private final DiskHeadDirection direction;
+
+        public DispatchRecord(
+                String processId,
+                String requestId,
+                int previousHeadBlock,
+                int newHeadBlock,
+                int traveledDistance,
+                DiskHeadDirection direction) {
+            this.processId = requireNonBlank(processId, "processId");
+            this.requestId = requireNonBlank(requestId, "requestId");
+            if (previousHeadBlock < 0 || newHeadBlock < 0 || traveledDistance < 0) {
+                throw new IllegalArgumentException("dispatch numeric values cannot be negative");
+            }
+            if (direction == null) {
+                throw new IllegalArgumentException("direction cannot be null");
+            }
+            this.previousHeadBlock = previousHeadBlock;
+            this.newHeadBlock = newHeadBlock;
+            this.traveledDistance = traveledDistance;
+            this.direction = direction;
+        }
+
+        public String getProcessId() {
+            return processId;
+        }
+
+        public String getRequestId() {
+            return requestId;
+        }
+
+        public int getPreviousHeadBlock() {
+            return previousHeadBlock;
+        }
+
+        public int getNewHeadBlock() {
+            return newHeadBlock;
+        }
+
+        public int getTraveledDistance() {
+            return traveledDistance;
+        }
+
+        public DiskHeadDirection getDirection() {
+            return direction;
+        }
+    }
+
+    private static String requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/coordinator/snapshot/SimulationSnapshotFactory.java
+++ b/src/main/java/ve/edu/unimet/so/project2/coordinator/snapshot/SimulationSnapshotFactory.java
@@ -1,0 +1,77 @@
+package ve.edu.unimet.so.project2.coordinator.snapshot;
+
+import ve.edu.unimet.so.project2.coordinator.state.CoordinatorProcessStore;
+import ve.edu.unimet.so.project2.disk.DiskHead;
+import ve.edu.unimet.so.project2.disk.SimulatedDisk;
+import ve.edu.unimet.so.project2.journal.JournalEntry;
+import ve.edu.unimet.so.project2.journal.JournalManager;
+import ve.edu.unimet.so.project2.locking.LockTable;
+import ve.edu.unimet.so.project2.scheduler.DiskSchedulingPolicy;
+
+public final class SimulationSnapshotFactory {
+
+    public SimulationSnapshot build(
+            DiskSchedulingPolicy policy,
+            SimulatedDisk disk,
+            CoordinatorProcessStore processStore,
+            LockTable lockTable,
+            JournalManager journalManager,
+            int totalSeekDistance,
+            int maxConcurrentDiskTasksObserved) {
+        DiskHead head = disk.getHead();
+        return new SimulationSnapshot(
+                policy,
+                head.getCurrentBlock(),
+                head.getDirection(),
+                totalSeekDistance,
+                maxConcurrentDiskTasksObserved,
+                processStore.getRunningProcess() == null ? null : processStore.getRunningProcess().getProcessId(),
+                processStore.getNewProcessSnapshots(),
+                processStore.getReadyProcessSnapshots(),
+                processStore.getBlockedProcessSnapshots(),
+                processStore.getTerminatedProcessSnapshots(),
+                buildLockSummaries(processStore, lockTable),
+                buildJournalSummaries(journalManager),
+                processStore.getDispatchHistorySnapshot());
+    }
+
+    private SimulationSnapshot.LockSummary[] buildLockSummaries(
+            CoordinatorProcessStore processStore,
+            LockTable lockTable) {
+        String[] trackedFileIds = processStore.getTrackedLockFileIdsSnapshot();
+        int activeCount = 0;
+        for (String fileId : trackedFileIds) {
+            if (lockTable.hasStateForFile(fileId)) {
+                activeCount++;
+            }
+        }
+
+        SimulationSnapshot.LockSummary[] summaries = new SimulationSnapshot.LockSummary[activeCount];
+        int index = 0;
+        for (String fileId : trackedFileIds) {
+            if (!lockTable.hasStateForFile(fileId)) {
+                continue;
+            }
+            summaries[index++] = new SimulationSnapshot.LockSummary(
+                    fileId,
+                    lockTable.getActiveLockCount(fileId),
+                    lockTable.getWaitingCount(fileId),
+                    lockTable.getPendingGrantCount(fileId));
+        }
+        return summaries;
+    }
+
+    private SimulationSnapshot.JournalEntrySummary[] buildJournalSummaries(JournalManager journalManager) {
+        SimulationSnapshot.JournalEntrySummary[] summaries =
+                new SimulationSnapshot.JournalEntrySummary[journalManager.getEntryCount()];
+        for (int i = 0; i < journalManager.getEntryCount(); i++) {
+            JournalEntry entry = journalManager.getEntryAt(i);
+            summaries[i] = new SimulationSnapshot.JournalEntrySummary(
+                    entry.getTransactionId(),
+                    entry.getOperationType(),
+                    entry.getTargetPath(),
+                    entry.getStatus());
+        }
+        return summaries;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/coordinator/state/CoordinatorProcessStore.java
+++ b/src/main/java/ve/edu/unimet/so/project2/coordinator/state/CoordinatorProcessStore.java
@@ -1,0 +1,226 @@
+package ve.edu.unimet.so.project2.coordinator.state;
+
+import ve.edu.unimet.so.project2.coordinator.core.PreparedOperationCommand;
+import ve.edu.unimet.so.project2.coordinator.snapshot.SimulationSnapshot;
+import ve.edu.unimet.so.project2.datastructures.LinkedQueue;
+import ve.edu.unimet.so.project2.datastructures.SimpleList;
+import ve.edu.unimet.so.project2.process.ProcessControlBlock;
+import ve.edu.unimet.so.project2.process.ProcessState;
+import ve.edu.unimet.so.project2.process.ResultStatus;
+import ve.edu.unimet.so.project2.process.WaitReason;
+
+public final class CoordinatorProcessStore {
+
+    private final LinkedQueue<ProcessControlBlock> newProcesses;
+    private final SimpleList<ProcessControlBlock> readyProcesses;
+    private final SimpleList<ProcessControlBlock> blockedProcesses;
+    private final SimpleList<SimulationSnapshot.ProcessSnapshot> terminatedProcesses;
+    private final SimpleList<ProcessExecutionContext> processContexts;
+    private final SimpleList<SimulationSnapshot.DispatchRecord> dispatchHistory;
+    private final SimpleList<String> trackedLockFileIds;
+
+    private ProcessControlBlock runningProcess;
+
+    public CoordinatorProcessStore() {
+        this.newProcesses = new LinkedQueue<>();
+        this.readyProcesses = new SimpleList<>();
+        this.blockedProcesses = new SimpleList<>();
+        this.terminatedProcesses = new SimpleList<>();
+        this.processContexts = new SimpleList<>();
+        this.dispatchHistory = new SimpleList<>();
+        this.trackedLockFileIds = new SimpleList<>();
+        this.runningProcess = null;
+    }
+
+    public void registerSubmittedProcess(ProcessControlBlock process, PreparedOperationCommand command) {
+        processContexts.add(new ProcessExecutionContext(process, command));
+        newProcesses.enqueue(process);
+    }
+
+    public boolean containsProcessId(String processId) {
+        for (int i = 0; i < processContexts.size(); i++) {
+            if (processContexts.get(i).getProcess().getProcessId().equals(processId)) {
+                return true;
+            }
+        }
+        for (int i = 0; i < terminatedProcesses.size(); i++) {
+            if (terminatedProcesses.get(i).getProcessId().equals(processId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public ProcessControlBlock admitNextNewProcess() {
+        return newProcesses.dequeue();
+    }
+
+    public void addReadyProcess(ProcessControlBlock process) {
+        readyProcesses.add(process);
+    }
+
+    public ProcessControlBlock[] getReadySnapshot() {
+        return toProcessArray(readyProcesses.toArray());
+    }
+
+    public ProcessControlBlock removeReadyProcessById(String processId) {
+        for (int i = 0; i < readyProcesses.size(); i++) {
+            ProcessControlBlock process = readyProcesses.get(i);
+            if (process.getProcessId().equals(processId)) {
+                readyProcesses.removeAt(i);
+                return process;
+            }
+        }
+        return null;
+    }
+
+    public void addBlockedProcess(ProcessControlBlock process) {
+        blockedProcesses.add(process);
+    }
+
+    public ProcessControlBlock removeBlockedProcessById(String processId) {
+        for (int i = 0; i < blockedProcesses.size(); i++) {
+            ProcessControlBlock process = blockedProcesses.get(i);
+            if (process.getProcessId().equals(processId)) {
+                blockedProcesses.removeAt(i);
+                return process;
+            }
+        }
+        return null;
+    }
+
+    public void addTerminatedProcess(ProcessControlBlock process) {
+        terminatedProcesses.add(toProcessSnapshot(process));
+    }
+
+    public void addRejectedTerminatedProcess(PreparedOperationCommand command, String errorMessage) {
+        terminatedProcesses.add(new SimulationSnapshot.ProcessSnapshot(
+                command.getProcessId(),
+                command.getRequestId(),
+                ProcessState.TERMINATED,
+                WaitReason.NONE,
+                ResultStatus.FAILED,
+                command.getTargetPath(),
+                command.getTargetBlock(),
+                null,
+                normalizeErrorMessage(errorMessage)));
+    }
+
+    public ProcessControlBlock getRunningProcess() {
+        return runningProcess;
+    }
+
+    public void setRunningProcess(ProcessControlBlock runningProcess) {
+        this.runningProcess = runningProcess;
+    }
+
+    public void clearRunningProcess() {
+        this.runningProcess = null;
+    }
+
+    public ProcessExecutionContext requireContext(String processId) {
+        for (int i = 0; i < processContexts.size(); i++) {
+            ProcessExecutionContext context = processContexts.get(i);
+            if (context.getProcess().getProcessId().equals(processId)) {
+                return context;
+            }
+        }
+        throw new IllegalArgumentException("process context not found for processId: " + processId);
+    }
+
+    public void registerDispatch(SimulationSnapshot.DispatchRecord record) {
+        dispatchHistory.add(record);
+    }
+
+    public SimulationSnapshot.DispatchRecord[] getDispatchHistorySnapshot() {
+        SimulationSnapshot.DispatchRecord[] snapshot =
+                new SimulationSnapshot.DispatchRecord[dispatchHistory.size()];
+        for (int i = 0; i < dispatchHistory.size(); i++) {
+            snapshot[i] = dispatchHistory.get(i);
+        }
+        return snapshot;
+    }
+
+    public void trackLockFileId(String fileId) {
+        if (fileId == null) {
+            return;
+        }
+        for (int i = 0; i < trackedLockFileIds.size(); i++) {
+            if (trackedLockFileIds.get(i).equals(fileId)) {
+                return;
+            }
+        }
+        trackedLockFileIds.add(fileId);
+    }
+
+    public String[] getTrackedLockFileIdsSnapshot() {
+        Object[] snapshot = trackedLockFileIds.toArray();
+        String[] result = new String[snapshot.length];
+        for (int i = 0; i < snapshot.length; i++) {
+            result[i] = (String) snapshot[i];
+        }
+        return result;
+    }
+
+    public SimulationSnapshot.ProcessSnapshot[] getNewProcessSnapshots() {
+        return toSnapshotArray(newProcesses.toArray());
+    }
+
+    public SimulationSnapshot.ProcessSnapshot[] getReadyProcessSnapshots() {
+        return toSnapshotArray(readyProcesses.toArray());
+    }
+
+    public SimulationSnapshot.ProcessSnapshot[] getBlockedProcessSnapshots() {
+        return toSnapshotArray(blockedProcesses.toArray());
+    }
+
+    public ProcessControlBlock[] getBlockedSnapshot() {
+        return toProcessArray(blockedProcesses.toArray());
+    }
+
+    public SimulationSnapshot.ProcessSnapshot[] getTerminatedProcessSnapshots() {
+        Object[] source = terminatedProcesses.toArray();
+        SimulationSnapshot.ProcessSnapshot[] result = new SimulationSnapshot.ProcessSnapshot[source.length];
+        for (int i = 0; i < source.length; i++) {
+            result[i] = (SimulationSnapshot.ProcessSnapshot) source[i];
+        }
+        return result;
+    }
+
+    private SimulationSnapshot.ProcessSnapshot[] toSnapshotArray(Object[] source) {
+        SimulationSnapshot.ProcessSnapshot[] result = new SimulationSnapshot.ProcessSnapshot[source.length];
+        for (int i = 0; i < source.length; i++) {
+            result[i] = toProcessSnapshot((ProcessControlBlock) source[i]);
+        }
+        return result;
+    }
+
+    private ProcessControlBlock[] toProcessArray(Object[] source) {
+        ProcessControlBlock[] result = new ProcessControlBlock[source.length];
+        for (int i = 0; i < source.length; i++) {
+            result[i] = (ProcessControlBlock) source[i];
+        }
+        return result;
+    }
+
+    private SimulationSnapshot.ProcessSnapshot toProcessSnapshot(ProcessControlBlock process) {
+        return new SimulationSnapshot.ProcessSnapshot(
+                process.getProcessId(),
+                process.getRequest().getRequestId(),
+                process.getState(),
+                process.getWaitReason(),
+                process.getResultStatus(),
+                process.getTargetPath(),
+                process.getTargetBlock(),
+                process.getBlockedByProcessId(),
+                process.getErrorMessage());
+    }
+
+    private String normalizeErrorMessage(String errorMessage) {
+        if (errorMessage == null) {
+            return "rejected operation";
+        }
+        String normalized = errorMessage.trim();
+        return normalized.isEmpty() ? "rejected operation" : normalized;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/coordinator/state/ProcessExecutionContext.java
+++ b/src/main/java/ve/edu/unimet/so/project2/coordinator/state/ProcessExecutionContext.java
@@ -1,0 +1,39 @@
+package ve.edu.unimet.so.project2.coordinator.state;
+
+import ve.edu.unimet.so.project2.coordinator.core.PreparedOperationCommand;
+import ve.edu.unimet.so.project2.process.ProcessControlBlock;
+
+public final class ProcessExecutionContext {
+
+    private final ProcessControlBlock process;
+    private final PreparedOperationCommand command;
+    private String transactionId;
+
+    public ProcessExecutionContext(ProcessControlBlock process, PreparedOperationCommand command) {
+        if (process == null) {
+            throw new IllegalArgumentException("process cannot be null");
+        }
+        if (command == null) {
+            throw new IllegalArgumentException("command cannot be null");
+        }
+        this.process = process;
+        this.command = command;
+        this.transactionId = null;
+    }
+
+    public ProcessControlBlock getProcess() {
+        return process;
+    }
+
+    public PreparedOperationCommand getCommand() {
+        return command;
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public void setTransactionId(String transactionId) {
+        this.transactionId = transactionId;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/scheduler/DiskScheduleDecision.java
+++ b/src/main/java/ve/edu/unimet/so/project2/scheduler/DiskScheduleDecision.java
@@ -1,0 +1,71 @@
+package ve.edu.unimet.so.project2.scheduler;
+
+import ve.edu.unimet.so.project2.disk.DiskHeadDirection;
+
+public final class DiskScheduleDecision {
+
+    private final String selectedProcessId;
+    private final String selectedRequestId;
+    private final int previousHeadBlock;
+    private final int newHeadBlock;
+    private final int traveledDistance;
+    private final DiskHeadDirection resultingDirection;
+
+    public DiskScheduleDecision(
+            String selectedProcessId,
+            String selectedRequestId,
+            int previousHeadBlock,
+            int newHeadBlock,
+            int traveledDistance,
+            DiskHeadDirection resultingDirection) {
+        this.selectedProcessId = requireNonBlank(selectedProcessId, "selectedProcessId");
+        this.selectedRequestId = requireNonBlank(selectedRequestId, "selectedRequestId");
+        if (previousHeadBlock < 0) {
+            throw new IllegalArgumentException("previousHeadBlock cannot be negative");
+        }
+        if (newHeadBlock < 0) {
+            throw new IllegalArgumentException("newHeadBlock cannot be negative");
+        }
+        if (traveledDistance < 0) {
+            throw new IllegalArgumentException("traveledDistance cannot be negative");
+        }
+        if (resultingDirection == null) {
+            throw new IllegalArgumentException("resultingDirection cannot be null");
+        }
+        this.previousHeadBlock = previousHeadBlock;
+        this.newHeadBlock = newHeadBlock;
+        this.traveledDistance = traveledDistance;
+        this.resultingDirection = resultingDirection;
+    }
+
+    public String getSelectedProcessId() {
+        return selectedProcessId;
+    }
+
+    public String getSelectedRequestId() {
+        return selectedRequestId;
+    }
+
+    public int getPreviousHeadBlock() {
+        return previousHeadBlock;
+    }
+
+    public int getNewHeadBlock() {
+        return newHeadBlock;
+    }
+
+    public int getTraveledDistance() {
+        return traveledDistance;
+    }
+
+    public DiskHeadDirection getResultingDirection() {
+        return resultingDirection;
+    }
+
+    private static String requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
+        }
+        return value;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/scheduler/DiskScheduler.java
+++ b/src/main/java/ve/edu/unimet/so/project2/scheduler/DiskScheduler.java
@@ -1,0 +1,231 @@
+package ve.edu.unimet.so.project2.scheduler;
+
+import ve.edu.unimet.so.project2.disk.DiskHead;
+import ve.edu.unimet.so.project2.disk.DiskHeadDirection;
+import ve.edu.unimet.so.project2.process.ProcessControlBlock;
+
+public final class DiskScheduler {
+
+    public DiskScheduleDecision selectNext(
+            DiskSchedulingPolicy policy,
+            DiskHead headSnapshot,
+            ProcessControlBlock[] readySnapshot,
+            int totalBlocks) {
+        if (policy == null) {
+            throw new IllegalArgumentException("policy cannot be null");
+        }
+        if (headSnapshot == null) {
+            throw new IllegalArgumentException("headSnapshot cannot be null");
+        }
+        if (readySnapshot == null) {
+            throw new IllegalArgumentException("readySnapshot cannot be null");
+        }
+        if (totalBlocks <= 0) {
+            throw new IllegalArgumentException("totalBlocks must be greater than zero");
+        }
+
+        ProcessControlBlock[] candidates = collectNonNullCandidates(readySnapshot);
+        if (candidates.length == 0) {
+            return null;
+        }
+
+        return switch (policy) {
+            case FIFO -> selectFifo(headSnapshot, candidates);
+            case SSTF -> selectSstf(headSnapshot, candidates);
+            case SCAN -> selectScan(headSnapshot, candidates, totalBlocks);
+            case C_SCAN -> selectCScan(headSnapshot, candidates, totalBlocks);
+        };
+    }
+
+    private DiskScheduleDecision selectFifo(DiskHead headSnapshot, ProcessControlBlock[] candidates) {
+        ProcessControlBlock selected = candidates[0];
+        for (int i = 1; i < candidates.length; i++) {
+            if (compareArrival(candidates[i], selected) < 0) {
+                selected = candidates[i];
+            }
+        }
+        return buildDirectDecision(headSnapshot, selected, headSnapshot.getDirection());
+    }
+
+    private DiskScheduleDecision selectSstf(DiskHead headSnapshot, ProcessControlBlock[] candidates) {
+        ProcessControlBlock selected = candidates[0];
+        int selectedDistance = distance(headSnapshot.getCurrentBlock(), selected.getTargetBlock());
+
+        for (int i = 1; i < candidates.length; i++) {
+            ProcessControlBlock candidate = candidates[i];
+            int candidateDistance = distance(headSnapshot.getCurrentBlock(), candidate.getTargetBlock());
+            if (candidateDistance < selectedDistance
+                    || (candidateDistance == selectedDistance && compareArrival(candidate, selected) < 0)) {
+                selected = candidate;
+                selectedDistance = candidateDistance;
+            }
+        }
+
+        return buildDirectDecision(headSnapshot, selected, headSnapshot.getDirection());
+    }
+
+    private DiskScheduleDecision selectScan(DiskHead headSnapshot, ProcessControlBlock[] candidates, int totalBlocks) {
+        ProcessControlBlock inDirection = findNearestInDirection(
+                candidates,
+                headSnapshot.getCurrentBlock(),
+                headSnapshot.getDirection());
+        if (inDirection != null) {
+            return buildDirectDecision(headSnapshot, inDirection, headSnapshot.getDirection());
+        }
+
+        DiskHeadDirection reversedDirection = reverse(headSnapshot.getDirection());
+        ProcessControlBlock oppositeDirection = findNearestInDirection(
+                candidates,
+                headSnapshot.getCurrentBlock(),
+                reversedDirection);
+        int edge = edgeFor(headSnapshot.getDirection(), totalBlocks);
+        int traveledDistance = distance(headSnapshot.getCurrentBlock(), edge)
+                + distance(edge, oppositeDirection.getTargetBlock());
+        return new DiskScheduleDecision(
+                oppositeDirection.getProcessId(),
+                oppositeDirection.getRequest().getRequestId(),
+                headSnapshot.getCurrentBlock(),
+                oppositeDirection.getTargetBlock(),
+                traveledDistance,
+                reversedDirection);
+    }
+
+    private DiskScheduleDecision selectCScan(DiskHead headSnapshot, ProcessControlBlock[] candidates, int totalBlocks) {
+        ProcessControlBlock inDirection = findNearestInDirection(
+                candidates,
+                headSnapshot.getCurrentBlock(),
+                headSnapshot.getDirection());
+        if (inDirection != null) {
+            return buildDirectDecision(headSnapshot, inDirection, headSnapshot.getDirection());
+        }
+
+        DiskHeadDirection direction = headSnapshot.getDirection();
+        ProcessControlBlock wrappedCandidate = findWrappedCandidate(candidates, direction);
+        int edge = edgeFor(direction, totalBlocks);
+        int wrapEdge = wrapEdgeFor(direction, totalBlocks);
+        int traveledDistance = distance(headSnapshot.getCurrentBlock(), edge)
+                + distance(edge, wrapEdge)
+                + distance(wrapEdge, wrappedCandidate.getTargetBlock());
+        return new DiskScheduleDecision(
+                wrappedCandidate.getProcessId(),
+                wrappedCandidate.getRequest().getRequestId(),
+                headSnapshot.getCurrentBlock(),
+                wrappedCandidate.getTargetBlock(),
+                traveledDistance,
+                direction);
+    }
+
+    private DiskScheduleDecision buildDirectDecision(
+            DiskHead headSnapshot,
+            ProcessControlBlock selected,
+            DiskHeadDirection resultingDirection) {
+        return new DiskScheduleDecision(
+                selected.getProcessId(),
+                selected.getRequest().getRequestId(),
+                headSnapshot.getCurrentBlock(),
+                selected.getTargetBlock(),
+                distance(headSnapshot.getCurrentBlock(), selected.getTargetBlock()),
+                resultingDirection);
+    }
+
+    private ProcessControlBlock findNearestInDirection(
+            ProcessControlBlock[] candidates,
+            int currentBlock,
+            DiskHeadDirection direction) {
+        ProcessControlBlock selected = null;
+        int selectedDistance = Integer.MAX_VALUE;
+
+        for (ProcessControlBlock candidate : candidates) {
+            if (!isInDirection(currentBlock, candidate.getTargetBlock(), direction)) {
+                continue;
+            }
+            int candidateDistance = distance(currentBlock, candidate.getTargetBlock());
+            if (selected == null
+                    || candidateDistance < selectedDistance
+                    || (candidateDistance == selectedDistance && compareArrival(candidate, selected) < 0)) {
+                selected = candidate;
+                selectedDistance = candidateDistance;
+            }
+        }
+
+        return selected;
+    }
+
+    private ProcessControlBlock findWrappedCandidate(ProcessControlBlock[] candidates, DiskHeadDirection direction) {
+        ProcessControlBlock selected = null;
+
+        for (ProcessControlBlock candidate : candidates) {
+            if (selected == null) {
+                selected = candidate;
+                continue;
+            }
+
+            if (direction == DiskHeadDirection.UP) {
+                if (candidate.getTargetBlock() < selected.getTargetBlock()
+                        || (candidate.getTargetBlock() == selected.getTargetBlock()
+                        && compareArrival(candidate, selected) < 0)) {
+                    selected = candidate;
+                }
+            } else if (candidate.getTargetBlock() > selected.getTargetBlock()
+                    || (candidate.getTargetBlock() == selected.getTargetBlock()
+                    && compareArrival(candidate, selected) < 0)) {
+                selected = candidate;
+            }
+        }
+
+        return selected;
+    }
+
+    private ProcessControlBlock[] collectNonNullCandidates(ProcessControlBlock[] readySnapshot) {
+        int count = 0;
+        for (ProcessControlBlock process : readySnapshot) {
+            if (process != null) {
+                count++;
+            }
+        }
+
+        ProcessControlBlock[] candidates = new ProcessControlBlock[count];
+        int index = 0;
+        for (ProcessControlBlock process : readySnapshot) {
+            if (process != null) {
+                candidates[index++] = process;
+            }
+        }
+        return candidates;
+    }
+
+    private boolean isInDirection(int currentBlock, int targetBlock, DiskHeadDirection direction) {
+        if (direction == DiskHeadDirection.UP) {
+            return targetBlock >= currentBlock;
+        }
+        return targetBlock <= currentBlock;
+    }
+
+    private int compareArrival(ProcessControlBlock left, ProcessControlBlock right) {
+        long leftArrival = left.getRequest().getArrivalOrder();
+        long rightArrival = right.getRequest().getArrivalOrder();
+        if (leftArrival < rightArrival) {
+            return -1;
+        }
+        if (leftArrival > rightArrival) {
+            return 1;
+        }
+        return left.getRequest().getRequestId().compareTo(right.getRequest().getRequestId());
+    }
+
+    private int distance(int from, int to) {
+        return Math.abs(from - to);
+    }
+
+    private int edgeFor(DiskHeadDirection direction, int totalBlocks) {
+        return direction == DiskHeadDirection.UP ? totalBlocks - 1 : 0;
+    }
+
+    private int wrapEdgeFor(DiskHeadDirection direction, int totalBlocks) {
+        return direction == DiskHeadDirection.UP ? 0 : totalBlocks - 1;
+    }
+
+    private DiskHeadDirection reverse(DiskHeadDirection direction) {
+        return direction == DiskHeadDirection.UP ? DiskHeadDirection.DOWN : DiskHeadDirection.UP;
+    }
+}

--- a/src/main/java/ve/edu/unimet/so/project2/scheduler/DiskSchedulingPolicy.java
+++ b/src/main/java/ve/edu/unimet/so/project2/scheduler/DiskSchedulingPolicy.java
@@ -1,0 +1,8 @@
+package ve.edu.unimet.so.project2.scheduler;
+
+public enum DiskSchedulingPolicy {
+    FIFO,
+    SSTF,
+    SCAN,
+    C_SCAN
+}

--- a/src/test/java/ve/edu/unimet/so/project2/coordinator/SimulationCoordinatorTest.java
+++ b/src/test/java/ve/edu/unimet/so/project2/coordinator/SimulationCoordinatorTest.java
@@ -1,0 +1,438 @@
+package ve.edu.unimet.so.project2.coordinator;
+
+import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import ve.edu.unimet.so.project2.coordinator.core.OperationApplyResult;
+import ve.edu.unimet.so.project2.coordinator.core.PreparedJournalData;
+import ve.edu.unimet.so.project2.coordinator.core.PreparedOperationCommand;
+import ve.edu.unimet.so.project2.coordinator.core.SimulationCoordinator;
+import ve.edu.unimet.so.project2.coordinator.snapshot.SimulationSnapshot;
+import ve.edu.unimet.so.project2.disk.DiskHeadDirection;
+import ve.edu.unimet.so.project2.disk.SimulatedDisk;
+import ve.edu.unimet.so.project2.filesystem.FsNodeType;
+import ve.edu.unimet.so.project2.journal.JournalStatus;
+import ve.edu.unimet.so.project2.journal.JournalManager;
+import ve.edu.unimet.so.project2.journal.undo.CreateDirectoryUndoData;
+import ve.edu.unimet.so.project2.journal.undo.UpdateRenameUndoData;
+import ve.edu.unimet.so.project2.locking.LockType;
+import ve.edu.unimet.so.project2.locking.LockTable;
+import ve.edu.unimet.so.project2.scheduler.DiskSchedulingPolicy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SimulationCoordinatorTest {
+
+    private SimulationCoordinator coordinator;
+
+    @AfterEach
+    @SuppressWarnings("unused")
+    void tearDown() {
+        if (coordinator != null) {
+            coordinator.shutdown();
+        }
+    }
+
+    @Test
+    void readOperationRunsWithCoordinatorHandlerOnCoordinatorThread() {
+        LockTable lockTable = new LockTable();
+        JournalManager journalManager = new JournalManager();
+        coordinator = createCoordinator(lockTable, journalManager);
+
+        AtomicReference<String> handlerThreadName = new AtomicReference<>();
+        AtomicReference<String> diskThreadName = new AtomicReference<>();
+
+        coordinator.start();
+        coordinator.submitOperation(new PreparedOperationCommand(
+                "REQ-1",
+                "PROC-1",
+                "user-1",
+                ve.edu.unimet.so.project2.process.IoOperationType.READ,
+                FsNodeType.FILE,
+                "/file-a",
+                "file-a",
+                40,
+                0,
+                LockType.SHARED,
+                null,
+                (command, process, diskResult) -> {
+                    handlerThreadName.set(Thread.currentThread().getName());
+                    diskThreadName.set(diskResult.getServiceThreadName());
+                    return OperationApplyResult.success();
+                }));
+
+        SimulationSnapshot snapshot = waitForSnapshot(s -> s.getTerminatedProcessesSnapshot().length == 1);
+        SimulationSnapshot.ProcessSnapshot terminated = snapshot.getTerminatedProcessesSnapshot()[0];
+
+        assertEquals("SimulationCoordinatorThread", handlerThreadName.get());
+        assertEquals("DiskExecutionThread", diskThreadName.get());
+        assertEquals(0, snapshot.getJournalEntriesSnapshot().length);
+        assertEquals("PROC-1", terminated.getProcessId());
+        assertEquals(ve.edu.unimet.so.project2.process.ResultStatus.SUCCESS, terminated.getResultStatus());
+        assertEquals(1, snapshot.getDispatchHistorySnapshot().length);
+        assertEquals(1, snapshot.getMaxConcurrentDiskTasksObserved());
+    }
+
+    @Test
+    void readIsCompatibleWithExistingSharedReader() {
+        LockTable lockTable = new LockTable();
+        JournalManager journalManager = new JournalManager();
+        lockTable.tryAcquire("shared-file", "external-reader", LockType.SHARED);
+        coordinator = createCoordinator(lockTable, journalManager);
+
+        coordinator.start();
+        coordinator.submitOperation(new PreparedOperationCommand(
+                "REQ-2",
+                "PROC-2",
+                "user-1",
+                ve.edu.unimet.so.project2.process.IoOperationType.READ,
+                FsNodeType.FILE,
+                "/shared-file",
+                "shared-file",
+                22,
+                0,
+                LockType.SHARED,
+                null,
+                (command, process, diskResult) -> OperationApplyResult.success()));
+
+        SimulationSnapshot snapshot = waitForSnapshot(s -> s.getTerminatedProcessesSnapshot().length == 1);
+
+        assertEquals(1, snapshot.getTerminatedProcessesSnapshot().length);
+        assertEquals(1, snapshot.getLocksSnapshot().length);
+        assertEquals(1, snapshot.getLocksSnapshot()[0].getActiveLockCount());
+        assertEquals(1, lockTable.getActiveLockCount("shared-file"));
+    }
+
+    @Test
+    void updateOnFileBlocksWhenSharedReaderExists() {
+        LockTable lockTable = new LockTable();
+        JournalManager journalManager = new JournalManager();
+        lockTable.tryAcquire("file-locked", "reader-1", LockType.SHARED);
+        coordinator = createCoordinator(lockTable, journalManager);
+
+        coordinator.start();
+        coordinator.submitOperation(new PreparedOperationCommand(
+                "REQ-3",
+                "PROC-3",
+                "user-1",
+                ve.edu.unimet.so.project2.process.IoOperationType.UPDATE,
+                FsNodeType.FILE,
+                "/file-locked",
+                "file-locked",
+                18,
+                0,
+                LockType.EXCLUSIVE,
+                new PreparedJournalData(
+                        new UpdateRenameUndoData("file-locked", "root", "/", "old.txt", "new.txt"),
+                        "file-locked",
+                        "user-1",
+                        "rename locked file"),
+                (command, process, diskResult) -> OperationApplyResult.success()));
+
+        SimulationSnapshot snapshot = waitForSnapshot(s -> s.getBlockedProcessesSnapshot().length == 1);
+        SimulationSnapshot.ProcessSnapshot blocked = snapshot.getBlockedProcessesSnapshot()[0];
+
+        assertEquals("PROC-3", blocked.getProcessId());
+        assertEquals(ve.edu.unimet.so.project2.process.WaitReason.WAITING_LOCK, blocked.getWaitReason());
+        assertEquals("reader-1", blocked.getBlockedByProcessId());
+        assertEquals(0, snapshot.getTerminatedProcessesSnapshot().length);
+    }
+
+    @Test
+    void updateOnDirectorySkipsFileLockTableAndCommitsJournal() {
+        LockTable lockTable = new LockTable();
+        JournalManager journalManager = new JournalManager();
+        coordinator = createCoordinator(lockTable, journalManager);
+
+        coordinator.start();
+        coordinator.submitOperation(new PreparedOperationCommand(
+                "REQ-4",
+                "PROC-4",
+                "user-1",
+                ve.edu.unimet.so.project2.process.IoOperationType.UPDATE,
+                FsNodeType.DIRECTORY,
+                "/docs",
+                "dir-1",
+                9,
+                0,
+                null,
+                new PreparedJournalData(
+                        new UpdateRenameUndoData("dir-1", "root", "/", "docs", "docs-renamed"),
+                        "dir-1",
+                        "user-1",
+                        "rename directory"),
+                (command, process, diskResult) -> OperationApplyResult.success()));
+
+        SimulationSnapshot snapshot = waitForSnapshot(s -> s.getTerminatedProcessesSnapshot().length == 1);
+
+        assertEquals(0, snapshot.getLocksSnapshot().length);
+        assertEquals(1, snapshot.getJournalEntriesSnapshot().length);
+        assertEquals(JournalStatus.COMMITTED, snapshot.getJournalEntriesSnapshot()[0].getStatus());
+    }
+
+    @Test
+    void failingHandlerLeavesJournalPendingUntilUndoExists() {
+        LockTable lockTable = new LockTable();
+        JournalManager journalManager = new JournalManager();
+        coordinator = createCoordinator(lockTable, journalManager);
+
+        coordinator.start();
+        coordinator.submitOperation(new PreparedOperationCommand(
+                "REQ-5",
+                "PROC-5",
+                "user-1",
+                ve.edu.unimet.so.project2.process.IoOperationType.UPDATE,
+                FsNodeType.DIRECTORY,
+                "/reports",
+                "dir-2",
+                12,
+                0,
+                null,
+                new PreparedJournalData(
+                        new UpdateRenameUndoData("dir-2", "root", "/", "reports", "reports-2026"),
+                        "dir-2",
+                        "user-1",
+                        "rename reports"),
+                (command, process, diskResult) -> OperationApplyResult.failed("simulated failure")));
+
+        SimulationSnapshot snapshot = waitForSnapshot(s -> s.getTerminatedProcessesSnapshot().length == 1);
+        SimulationSnapshot.ProcessSnapshot terminated = snapshot.getTerminatedProcessesSnapshot()[0];
+
+        assertEquals(1, snapshot.getJournalEntriesSnapshot().length);
+        assertEquals(JournalStatus.PENDING, snapshot.getJournalEntriesSnapshot()[0].getStatus());
+        assertEquals(ve.edu.unimet.so.project2.process.ResultStatus.FAILED, terminated.getResultStatus());
+        assertEquals("simulated failure", terminated.getErrorMessage());
+        assertEquals(1, snapshot.getMaxConcurrentDiskTasksObserved());
+    }
+
+    @Test
+    void blockedProcessWakesAfterExternalLockRelease() {
+        LockTable lockTable = new LockTable();
+        JournalManager journalManager = new JournalManager();
+        lockTable.tryAcquire("file-external", "external-reader", LockType.SHARED);
+        coordinator = createCoordinator(lockTable, journalManager);
+
+        coordinator.start();
+        coordinator.submitOperation(new PreparedOperationCommand(
+                "REQ-EXT",
+                "PROC-EXT",
+                "user-1",
+                ve.edu.unimet.so.project2.process.IoOperationType.UPDATE,
+                FsNodeType.FILE,
+                "/file-external",
+                "file-external",
+                21,
+                0,
+                LockType.EXCLUSIVE,
+                new PreparedJournalData(
+                        new UpdateRenameUndoData("file-external", "root", "/", "locked.txt", "updated.txt"),
+                        "file-external",
+                        "user-1",
+                        "update after external release"),
+                (command, process, diskResult) -> OperationApplyResult.success()));
+
+        SimulationSnapshot blockedSnapshot = waitForSnapshot(s -> s.getBlockedProcessesSnapshot().length == 1);
+        assertEquals("PROC-EXT", blockedSnapshot.getBlockedProcessesSnapshot()[0].getProcessId());
+
+        lockTable.releaseByProcess("file-external", "external-reader");
+
+        SimulationSnapshot completedSnapshot = waitForSnapshot(s -> s.getTerminatedProcessesSnapshot().length == 1);
+        SimulationSnapshot.ProcessSnapshot terminated = completedSnapshot.getTerminatedProcessesSnapshot()[0];
+
+        assertEquals("PROC-EXT", terminated.getProcessId());
+        assertEquals(ve.edu.unimet.so.project2.process.ResultStatus.SUCCESS, terminated.getResultStatus());
+        assertEquals(0, completedSnapshot.getBlockedProcessesSnapshot().length);
+        assertEquals(0, lockTable.getActiveLockCount("file-external"));
+    }
+
+    @Test
+    void invalidQueuedCommandDoesNotKillCoordinatorLoop() {
+        LockTable lockTable = new LockTable();
+        JournalManager journalManager = new JournalManager();
+        coordinator = createCoordinator(lockTable, journalManager);
+
+        coordinator.start();
+        coordinator.submitOperation(new PreparedOperationCommand(
+                "REQ-BAD",
+                "PROC-BAD",
+                "user-1",
+                ve.edu.unimet.so.project2.process.IoOperationType.READ,
+                FsNodeType.DIRECTORY,
+                "/dir-as-read",
+                "dir-bad",
+                15,
+                0,
+                LockType.SHARED,
+                null,
+                (command, process, diskResult) -> OperationApplyResult.success()));
+        coordinator.submitOperation(new PreparedOperationCommand(
+                "REQ-GOOD",
+                "PROC-GOOD",
+                "user-1",
+                ve.edu.unimet.so.project2.process.IoOperationType.READ,
+                FsNodeType.FILE,
+                "/good-file",
+                "file-good",
+                16,
+                0,
+                LockType.SHARED,
+                null,
+                (command, process, diskResult) -> OperationApplyResult.success()));
+
+        SimulationSnapshot snapshot = waitForSnapshot(s -> s.getTerminatedProcessesSnapshot().length == 2);
+
+        SimulationSnapshot.ProcessSnapshot first = snapshot.getTerminatedProcessesSnapshot()[0];
+        SimulationSnapshot.ProcessSnapshot second = snapshot.getTerminatedProcessesSnapshot()[1];
+
+        assertEquals("PROC-BAD", first.getProcessId());
+        assertEquals(ve.edu.unimet.so.project2.process.ResultStatus.FAILED, first.getResultStatus());
+        assertEquals("PROC-GOOD", second.getProcessId());
+        assertEquals(ve.edu.unimet.so.project2.process.ResultStatus.SUCCESS, second.getResultStatus());
+    }
+
+    @Test
+    void duplicateProcessIdIsRejectedBeforeAmbiguousContextLookup() {
+        LockTable lockTable = new LockTable();
+        JournalManager journalManager = new JournalManager();
+        coordinator = createCoordinator(lockTable, journalManager);
+
+        AtomicInteger firstHandlerCalls = new AtomicInteger();
+        AtomicInteger secondHandlerCalls = new AtomicInteger();
+
+        coordinator.start();
+        coordinator.submitOperation(new PreparedOperationCommand(
+                "REQ-DUP-1",
+                "PROC-DUP",
+                "user-1",
+                ve.edu.unimet.so.project2.process.IoOperationType.READ,
+                FsNodeType.FILE,
+                "/dup-1",
+                "file-dup-1",
+                30,
+                0,
+                LockType.SHARED,
+                null,
+                (command, process, diskResult) -> {
+                    firstHandlerCalls.incrementAndGet();
+                    return OperationApplyResult.success();
+                }));
+        coordinator.submitOperation(new PreparedOperationCommand(
+                "REQ-DUP-2",
+                "PROC-DUP",
+                "user-1",
+                ve.edu.unimet.so.project2.process.IoOperationType.READ,
+                FsNodeType.FILE,
+                "/dup-2",
+                "file-dup-2",
+                31,
+                0,
+                LockType.SHARED,
+                null,
+                (command, process, diskResult) -> {
+                    secondHandlerCalls.incrementAndGet();
+                    return OperationApplyResult.success();
+                }));
+
+        SimulationSnapshot snapshot = waitForSnapshot(s -> s.getTerminatedProcessesSnapshot().length == 2);
+        SimulationSnapshot.ProcessSnapshot firstTerminated = findTerminatedByRequestId(snapshot, "REQ-DUP-1");
+        SimulationSnapshot.ProcessSnapshot secondTerminated = findTerminatedByRequestId(snapshot, "REQ-DUP-2");
+
+        assertEquals(ve.edu.unimet.so.project2.process.ResultStatus.SUCCESS, firstTerminated.getResultStatus());
+        assertEquals(ve.edu.unimet.so.project2.process.ResultStatus.FAILED, secondTerminated.getResultStatus());
+        assertTrue(secondTerminated.getErrorMessage().contains("duplicate processId"));
+        assertEquals(1, firstHandlerCalls.get());
+        assertEquals(0, secondHandlerCalls.get());
+    }
+
+    @Test
+    void incompatibleUndoDataIsRejectedEarly() {
+        assertThrows(IllegalArgumentException.class, () -> new PreparedOperationCommand(
+                "REQ-UNDO",
+                "PROC-UNDO",
+                "user-1",
+                ve.edu.unimet.so.project2.process.IoOperationType.UPDATE,
+                FsNodeType.DIRECTORY,
+                "/docs",
+                "dir-undo",
+                7,
+                0,
+                null,
+                new PreparedJournalData(
+                        new CreateDirectoryUndoData("dir-undo", "root", "/"),
+                        "dir-undo",
+                        "user-1",
+                        "wrong undo type"),
+                (command, process, diskResult) -> OperationApplyResult.success()));
+    }
+
+    @Test
+    void outOfRangeTargetBlockIsRejectedBeforeDispatch() {
+        LockTable lockTable = new LockTable();
+        JournalManager journalManager = new JournalManager();
+        coordinator = createCoordinator(lockTable, journalManager);
+
+        coordinator.start();
+        coordinator.submitOperation(new PreparedOperationCommand(
+                "REQ-RANGE",
+                "PROC-RANGE",
+                "user-1",
+                ve.edu.unimet.so.project2.process.IoOperationType.READ,
+                FsNodeType.FILE,
+                "/bad-block",
+                "file-range",
+                999,
+                0,
+                LockType.SHARED,
+                null,
+                (command, process, diskResult) -> OperationApplyResult.success()));
+
+        SimulationSnapshot snapshot = waitForSnapshot(s -> s.getTerminatedProcessesSnapshot().length == 1);
+        SimulationSnapshot.ProcessSnapshot terminated = snapshot.getTerminatedProcessesSnapshot()[0];
+
+        assertEquals("PROC-RANGE", terminated.getProcessId());
+        assertEquals(ve.edu.unimet.so.project2.process.ResultStatus.FAILED, terminated.getResultStatus());
+        assertEquals(0, snapshot.getDispatchHistorySnapshot().length);
+        assertEquals(0, snapshot.getLocksSnapshot().length);
+        assertEquals(999, terminated.getTargetBlock());
+    }
+
+    private SimulationCoordinator createCoordinator(LockTable lockTable, JournalManager journalManager) {
+        return new SimulationCoordinator(
+                new SimulatedDisk(200, 10, DiskHeadDirection.UP),
+                lockTable,
+                journalManager,
+                DiskSchedulingPolicy.FIFO);
+    }
+
+    private SimulationSnapshot.ProcessSnapshot findTerminatedByRequestId(
+            SimulationSnapshot snapshot,
+            String requestId) {
+        for (SimulationSnapshot.ProcessSnapshot process : snapshot.getTerminatedProcessesSnapshot()) {
+            if (process.getRequestId().equals(requestId)) {
+                return process;
+            }
+        }
+        throw new AssertionError("terminated process not found for requestId: " + requestId);
+    }
+
+    private SimulationSnapshot waitForSnapshot(Predicate<SimulationSnapshot> predicate) {
+        long deadline = System.currentTimeMillis() + 5000L;
+        SimulationSnapshot latest = null;
+        while (System.currentTimeMillis() < deadline) {
+            latest = coordinator.getLatestSnapshot();
+            if (latest != null && predicate.test(latest)) {
+                return latest;
+            }
+            LockSupport.parkNanos(10_000_000L);
+        }
+        assertNotNull(latest);
+        assertTrue(predicate.test(latest), "timeout waiting for coordinator snapshot condition");
+        return latest;
+    }
+}

--- a/src/test/java/ve/edu/unimet/so/project2/scheduler/DiskSchedulerTest.java
+++ b/src/test/java/ve/edu/unimet/so/project2/scheduler/DiskSchedulerTest.java
@@ -1,0 +1,121 @@
+package ve.edu.unimet.so.project2.scheduler;
+
+import org.junit.jupiter.api.Test;
+import ve.edu.unimet.so.project2.disk.DiskHeadDirection;
+import ve.edu.unimet.so.project2.disk.SimulatedDisk;
+import ve.edu.unimet.so.project2.filesystem.FsNodeType;
+import ve.edu.unimet.so.project2.locking.LockType;
+import ve.edu.unimet.so.project2.process.IoOperationType;
+import ve.edu.unimet.so.project2.process.IoRequest;
+import ve.edu.unimet.so.project2.process.ProcessControlBlock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class DiskSchedulerTest {
+
+    private final DiskScheduler scheduler = new DiskScheduler();
+
+    @Test
+    void fifoUsesArrivalOrder() {
+        SimulatedDisk disk = new SimulatedDisk(200, 50, DiskHeadDirection.UP);
+        ProcessControlBlock older = createFileProcess("P1", "R1", 20, 1L, IoOperationType.READ, LockType.SHARED);
+        ProcessControlBlock newer = createFileProcess("P2", "R2", 60, 2L, IoOperationType.READ, LockType.SHARED);
+
+        DiskScheduleDecision decision = scheduler.selectNext(
+                DiskSchedulingPolicy.FIFO,
+                disk.getHead(),
+                new ProcessControlBlock[] { newer, older },
+                disk.getTotalBlocks());
+
+        assertNotNull(decision);
+        assertEquals("P1", decision.getSelectedProcessId());
+        assertEquals(30, decision.getTraveledDistance());
+    }
+
+    @Test
+    void sstfUsesDistanceThenArrivalThenRequestId() {
+        SimulatedDisk disk = new SimulatedDisk(200, 50, DiskHeadDirection.UP);
+        ProcessControlBlock farther = createFileProcess("P1", "R2", 60, 5L, IoOperationType.READ, LockType.SHARED);
+        ProcessControlBlock closerWithEarlierArrival = createFileProcess("P2", "R3", 48, 2L, IoOperationType.READ, LockType.SHARED);
+        ProcessControlBlock sameDistanceLaterArrival = createFileProcess("P3", "R1", 52, 7L, IoOperationType.READ, LockType.SHARED);
+
+        DiskScheduleDecision decision = scheduler.selectNext(
+                DiskSchedulingPolicy.SSTF,
+                disk.getHead(),
+                new ProcessControlBlock[] { farther, sameDistanceLaterArrival, closerWithEarlierArrival },
+                disk.getTotalBlocks());
+
+        assertNotNull(decision);
+        assertEquals("P2", decision.getSelectedProcessId());
+        assertEquals(2, decision.getTraveledDistance());
+    }
+
+    @Test
+    void scanReversesDirectionUsingRealEdgeWhenNeeded() {
+        SimulatedDisk disk = new SimulatedDisk(200, 50, DiskHeadDirection.UP);
+        ProcessControlBlock lowerBlock = createFileProcess("P1", "R1", 20, 1L, IoOperationType.READ, LockType.SHARED);
+        ProcessControlBlock anotherLowerBlock = createFileProcess("P2", "R2", 10, 2L, IoOperationType.READ, LockType.SHARED);
+
+        DiskScheduleDecision decision = scheduler.selectNext(
+                DiskSchedulingPolicy.SCAN,
+                disk.getHead(),
+                new ProcessControlBlock[] { lowerBlock, anotherLowerBlock },
+                disk.getTotalBlocks());
+
+        assertNotNull(decision);
+        assertEquals("P1", decision.getSelectedProcessId());
+        assertEquals(DiskHeadDirection.DOWN, decision.getResultingDirection());
+        assertEquals((199 - 50) + (199 - 20), decision.getTraveledDistance());
+    }
+
+    @Test
+    void cScanWrapsAndKeepsDirection() {
+        SimulatedDisk disk = new SimulatedDisk(200, 50, DiskHeadDirection.UP);
+        ProcessControlBlock wrappedTarget = createFileProcess("P1", "R1", 20, 1L, IoOperationType.READ, LockType.SHARED);
+        ProcessControlBlock laterWrappedTarget = createFileProcess("P2", "R2", 40, 2L, IoOperationType.READ, LockType.SHARED);
+
+        DiskScheduleDecision decision = scheduler.selectNext(
+                DiskSchedulingPolicy.C_SCAN,
+                disk.getHead(),
+                new ProcessControlBlock[] { wrappedTarget, laterWrappedTarget },
+                disk.getTotalBlocks());
+
+        assertNotNull(decision);
+        assertEquals("P1", decision.getSelectedProcessId());
+        assertEquals(DiskHeadDirection.UP, decision.getResultingDirection());
+        assertEquals((199 - 50) + 199 + 20, decision.getTraveledDistance());
+    }
+
+    private ProcessControlBlock createFileProcess(
+            String processId,
+            String requestId,
+            int targetBlock,
+            long arrivalOrder,
+            IoOperationType operationType,
+            LockType lockType) {
+        IoRequest request = new IoRequest(
+                requestId,
+                processId,
+                operationType,
+                FsNodeType.FILE,
+                "/file-" + processId,
+                "file-" + processId,
+                targetBlock,
+                0,
+                "user-1",
+                arrivalOrder);
+        ProcessControlBlock pcb = new ProcessControlBlock(
+                processId,
+                "user-1",
+                request,
+                FsNodeType.FILE,
+                "file-" + processId,
+                "/file-" + processId,
+                targetBlock,
+                lockType,
+                arrivalOrder);
+        pcb.markReady(arrivalOrder + 1);
+        return pcb;
+    }
+}


### PR DESCRIPTION
Add the first solid coordinator/scheduler layer with immutable snapshots, basic lock and journal integration, and regression coverage for key failure cases.

On top of this, I finally caved and added unit tests because the project was having quite a few bugs while I was developing the core, so this should make things a bit easier going forward.